### PR TITLE
Correctly highlight properties after function calls

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -193,7 +193,7 @@ private extension SwiftGrammar {
                 }
             }
 
-            return segment.tokens.next.isAny(of: "(", "()", "())", "(.", "({")
+            return segment.tokens.next.isAny(of: "(", "()", "())", "(.", "({", "().")
         }
     }
 
@@ -268,7 +268,7 @@ private extension SwiftGrammar {
                 return false
             }
 
-            guard segment.tokens.previous.isAny(of: ".", "?.") else {
+            guard segment.tokens.previous.isAny(of: ".", "?.", "().", ").") else {
                 return false
             }
 

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -55,6 +55,26 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testAccessingPropertyAfterFunctionCallWithoutArguments() {
+        let components = highlighter.highlight("call().property")
+
+        XCTAssertEqual(components, [
+            .token("call", .call),
+            .plainText("()."),
+            .token("property", .property)
+        ])
+    }
+
+    func testAccessingPropertyAfterFunctionCallWithArguments() {
+        let components = highlighter.highlight("call(argument).property")
+
+        XCTAssertEqual(components, [
+            .token("call", .call),
+            .plainText("(argument)."),
+            .token("property", .property)
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -65,7 +85,9 @@ extension FunctionCallTests {
         return [
             ("testFunctionCallWithIntegers", testFunctionCallWithIntegers),
             ("testImplicitInitializerCall", testImplicitInitializerCall),
-            ("testExplicitInitializerCall", testExplicitInitializerCall)
+            ("testExplicitInitializerCall", testExplicitInitializerCall),
+            ("testAccessingPropertyAfterFunctionCallWithoutArguments", testAccessingPropertyAfterFunctionCallWithoutArguments),
+            ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes highlighting in the following scenarios:

```
call().property
call(argument).property
```