### PR TITLE
Streamline cross-platform implementation

### DIFF
--- a/Sources/Splash/Theming/Color.swift
+++ b/Sources/Splash/Theming/Color.swift
@@ -23,3 +23,34 @@ public struct Color {
         self.alpha = alpha
     }
 }
+
+#if !os(Linux)
+internal extension Color {
+    var renderable: Renderable {
+        return Renderable(
+            red: CGFloat(red),
+            green: CGFloat(green),
+            blue: CGFloat(blue),
+            alpha: CGFloat(alpha)
+        )
+    }
+}
+#endif
+
+#if os(iOS)
+
+import UIKit
+
+internal extension Color {
+    typealias Renderable = UIColor
+}
+
+#elseif os(macOS)
+
+import Cocoa
+
+internal extension Color {
+    typealias Renderable = NSColor
+}
+
+#endif

--- a/Sources/Splash/Theming/Color.swift
+++ b/Sources/Splash/Theming/Color.swift
@@ -6,6 +6,8 @@
 
 import Foundation
 
+#if !os(Linux)
+
 /// A representation of a color, for use with a `Theme`.
 /// Since Splash aims to be cross-platform, it uses this
 /// simplified color representation rather than `NSColor`
@@ -24,7 +26,6 @@ public struct Color {
     }
 }
 
-#if !os(Linux)
 internal extension Color {
     var renderable: Renderable {
         return Renderable(
@@ -35,6 +36,7 @@ internal extension Color {
         )
     }
 }
+
 #endif
 
 #if os(iOS)

--- a/Sources/Splash/Theming/Theme+Defaults.swift
+++ b/Sources/Splash/Theming/Theme+Defaults.swift
@@ -6,13 +6,9 @@
 
 import Foundation
 
-/*
- * Extends the Theme struct with static properties that
- * represent common Xcode defaults as well as community
- * favourites.
- */
-public extension Theme {
+#if !os(Linux)
 
+public extension Theme {
     /// Create a theme matching the "Sundell's Colors" Xcode theme
     static func sundellsColors(withFont font: Font) -> Theme {
         return Theme(
@@ -36,6 +32,7 @@ public extension Theme {
         )
     }
 
+    /// Create a theme matching Xcode's "Midnight" theme
     static func midnight(withFont font: Font) -> Theme {
         return Theme(
             font: font,
@@ -58,6 +55,7 @@ public extension Theme {
         )
     }
 
+    /// Creating a theme matching the colors used for the WWDC 2017 sample code
     static func wwdc17(withFont font: Font) -> Theme {
         return Theme(
             font: font,
@@ -80,6 +78,7 @@ public extension Theme {
         )
     }
 
+    /// Creating a theme matching the colors used for the WWDC 2018 sample code
     static func wwdc18(withFont font: Font) -> Theme {
         return Theme(
             font: font,
@@ -102,6 +101,7 @@ public extension Theme {
         )
     }
 
+    /// Create a theme matching Xcode's "Sunset" theme
     static func sunset(withFont font: Font) -> Theme {
         return Theme(
             font: font,
@@ -124,6 +124,7 @@ public extension Theme {
         )
     }
 
+    /// Create a theme matching Xcode's "Presentation" theme
     static func presentation(withFont font: Font) -> Theme {
         return Theme(
             font: font,
@@ -145,5 +146,6 @@ public extension Theme {
             ]
         )
     }
-
 }
+
+#endif

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -6,10 +6,11 @@
 
 import Foundation
 
+#if !os(Linux)
+
 /// A theme describes what fonts and colors to use when rendering
-/// certain output formats - such as `NSAttributedString`. A default
-/// implementation is provided that matches the "Sundell's Colors"
-/// Xcode theme, by using the `sundellsColors(withFont:)` method.
+/// certain output formats - such as `NSAttributedString`. Several
+/// default implementations are provided - see Theme+Defaults.swift.
 public struct Theme {
     /// What font to use to render the highlighted text
     public var font: Font
@@ -24,3 +25,5 @@ public struct Theme {
         self.tokenColors = tokenColors
     }
 }
+
+#endif


### PR DESCRIPTION
Now that we’re making Splash support iOS as well as Mac + Linux, we need to create some nice abstractions to make sure that we can share as much code as possible between all platforms.

- Define `Font.Loaded` and `Color.Renderable` as platform-specific typealiases for system fonts and colors.
- Don’t compile in non-Linux compatible code when building for Linux.
- Make `Font` and `Color` handle all conversion themselves, so that `AttributedStringOutputFormat` can be kept more clean.

Also includes some improved documentation for `Theme`.