### PR TITLE
Add Linux CI using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+os: linux
+language: generic
+sudo: required
+dist: trusty
+env:
+    - SWIFT_VERSION=4.1
+install:
+    - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+script:
+    - swift test


### PR DESCRIPTION
We’re using Bitrise for Mac builds, but for Linux let’s use Travis to make sure we don’t cause regressions on Linux.