### PR TITLE
Correctly handle static methods called on a generic type

### DIFF
--- a/Sources/Splash/Extensions/Equatable/Equatable+AnyOf.swift
+++ b/Sources/Splash/Extensions/Equatable/Equatable+AnyOf.swift
@@ -11,7 +11,7 @@ extension Equatable {
         return candidates.contains(self)
     }
 
-    func isAny(of candidates: [Self]) -> Bool {
+    func isAny<S: Sequence>(of candidates: S) -> Bool where S.Element == Self {
         return candidates.contains(self)
     }
 }

--- a/Sources/Splash/Tokenizing/Segment.swift
+++ b/Sources/Splash/Tokenizing/Segment.swift
@@ -24,16 +24,18 @@ public struct Segment {
 public extension Segment {
     /// A collection of tokens included in a code segment
     struct Tokens {
+        /// All tokens that have been found so far (excluding the current one)
+        public var all: [String]
         /// The number of times a given token has been found up until this point
-        var counts: [String : Int]
+        public var counts: [String : Int]
         /// The tokens that were previously found on the same line as the current one
-        var onSameLine: [String]
+        public var onSameLine: [String]
         /// The token that was previously found (may be on a different line)
-        var previous: String?
+        public var previous: String?
         /// The current token which is currently being evaluated
-        var current: String
+        public var current: String
         /// Any upcoming token that will follow the current one
-        var next: String?
+        public var next: String?
     }
 }
 

--- a/Sources/Splash/Tokenizing/Tokenizer.swift
+++ b/Sources/Splash/Tokenizing/Tokenizer.swift
@@ -43,6 +43,7 @@ private extension Tokenizer {
         private let delimiters: CharacterSet
         private var index: String.Index?
         private var tokenCounts = [String : Int]()
+        private var allTokens = [String]()
         private var lineTokens = [String]()
         private var segments: (current: Segment?, previous: Segment?)
 
@@ -132,6 +133,7 @@ private extension Tokenizer {
 
         private func makeSegment(with component: Component, at index: String.Index) -> Segment {
             let tokens = Segment.Tokens(
+                all: allTokens,
                 counts: tokenCounts,
                 onSameLine: lineTokens,
                 previous: segments.current?.tokens.current,
@@ -154,6 +156,8 @@ private extension Tokenizer {
             var count = tokenCounts[segment.tokens.current] ?? 0
             count += 1
             tokenCounts[segment.tokens.current] = count
+
+            allTokens.append(segment.tokens.current)
 
             if segment.isLastOnLine {
                 lineTokens = []

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -75,6 +75,19 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCallingStaticMethodOnGenericType() {
+        let components = highlighter.highlight("Array<String>.call()")
+
+        XCTAssertEqual(components, [
+            .token("Array", .type),
+            .plainText("<"),
+            .token("String", .type),
+            .plainText(">."),
+            .token("call", .call),
+            .plainText("()")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -87,7 +100,8 @@ extension FunctionCallTests {
             ("testImplicitInitializerCall", testImplicitInitializerCall),
             ("testExplicitInitializerCall", testExplicitInitializerCall),
             ("testAccessingPropertyAfterFunctionCallWithoutArguments", testAccessingPropertyAfterFunctionCallWithoutArguments),
-            ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments)
+            ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments),
+            ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes syntax highlighting for the following scenario:

```
Type<GenericType>.call()
```

Highlighting generic types is especially tricky, since we want them to be highlighted when appearing at the call site, like above - but we don’t want to highlight them when they are being declared. Hopefully with this fix all/most edge cases are covered.