### PR TITLE
HTMLOutputFormat: Escape < and > characters

### DIFF
--- a/Sources/Splash/Output/HTMLOutputFormat.swift
+++ b/Sources/Splash/Output/HTMLOutputFormat.swift
@@ -33,11 +33,11 @@ public extension HTMLOutputFormat {
         }
 
         public mutating func addToken(_ token: String, ofType type: TokenType) {
-            html.append("<span class=\"\(classPrefix)\(type.rawValue)\">\(token)</span>")
+            html.append("<span class=\"\(classPrefix)\(type.rawValue)\">\(token.escaped)</span>")
         }
 
         public mutating func addPlainText(_ text: String) {
-            html.append(text)
+            html.append(text.escaped)
         }
 
         public mutating func addWhitespace(_ whitespace: String) {
@@ -47,5 +47,12 @@ public extension HTMLOutputFormat {
         public func build() -> String {
             return html
         }
+    }
+}
+
+private extension String {
+    var escaped: String {
+        return replacingOccurrences(of: "<", with: "&lt;")
+               .replacingOccurrences(of: ">", with: "&gt;")
     }
 }

--- a/Tests/SplashTests/Core/SplashTestCase.swift
+++ b/Tests/SplashTests/Core/SplashTestCase.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+
+/// Abstract base class for all Splash tests
+class SplashTestCase: XCTestCase {
+    #if !os(Linux)
+    func testHasLinuxVerificationTest() {
+        let concreteType = type(of: self)
+
+        guard concreteType != SyntaxHighlighterTestCase.self else {
+            return
+        }
+
+        guard concreteType != SplashTestCase.self else {
+            return
+        }
+
+        XCTAssertTrue(concreteType.testNames.contains("testAllTestsRunOnLinux"),
+                      "\(concreteType) doesn't have a  test that verifies that its tests run on Linux")
+    }
+    #endif
+}

--- a/Tests/SplashTests/Core/SyntaxHighlighterTestCase.swift
+++ b/Tests/SplashTests/Core/SyntaxHighlighterTestCase.swift
@@ -10,7 +10,7 @@ import Splash
 
 /// Test case used as an abstract base class for all tests relating to
 /// syntax highlighting. For all such tests, the Swift grammar is used.
-class SyntaxHighlighterTestCase: XCTestCase {
+class SyntaxHighlighterTestCase: SplashTestCase {
     private(set) var highlighter: SyntaxHighlighter<OutputFormatMock>!
     private(set) var builder: OutputBuilderMock!
 
@@ -19,17 +19,4 @@ class SyntaxHighlighterTestCase: XCTestCase {
         builder = OutputBuilderMock()
         highlighter = SyntaxHighlighter(format: OutputFormatMock(builder: builder))
     }
-
-    #if os(macOS)
-    func testHasLinuxVerificationTest() {
-        let concreteType = type(of: self)
-
-        guard concreteType != SyntaxHighlighterTestCase.self else {
-            return
-        }
-
-        XCTAssertTrue(concreteType.testNames.contains("testAllTestsRunOnLinux"),
-                      "All test cases should have a test that verify that their tests run on Linux")
-    }
-    #endif
 }

--- a/Tests/SplashTests/Tests/HTMLOutputFormatTests.swift
+++ b/Tests/SplashTests/Tests/HTMLOutputFormatTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import XCTest
+import Splash
+
+final class HTMLOutputFormatTests: SplashTestCase {
+    private var highlighter: SyntaxHighlighter<HTMLOutputFormat>!
+
+    override func setUp() {
+        super.setUp()
+        highlighter = SyntaxHighlighter(format: HTMLOutputFormat())
+    }
+
+    func testStrippingGreaterAndLessThanCharactersFromOutput() {
+        let html = highlighter.highlight("Array<String>")
+
+        XCTAssertEqual(html, """
+        <span class="type">Array</span>&lt;<span class="type">String</span>&gt;
+        """)
+    }
+
+    func testAllTestsRunOnLinux() {
+        XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
+    }
+}
+
+extension HTMLOutputFormatTests {
+    static var allTests: [(String, TestClosure<HTMLOutputFormatTests>)] {
+        return [
+            ("testStrippingGreaterAndLessThanCharactersFromOutput", testStrippingGreaterAndLessThanCharactersFromOutput)
+        ]
+    }
+}


### PR DESCRIPTION
This patch makes `HTMLOutputFormat` correctly escape all < and > characters that occur in source code. Otherwise, a web browser rendering the resulting HTML will interpret those characters as tags.