### PR TITLE
Highlight enums used as subscripting keys

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -262,7 +262,7 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .dotAccess }
 
         func matches(_ segment: Segment) -> Bool {
-            guard segment.tokens.previous.isAny(of: ".", "(.") else {
+            guard segment.tokens.previous.isAny(of: ".", "(.", "[.") else {
                 return false
             }
 

--- a/Tests/SplashTests/Tests/EnumTests.swift
+++ b/Tests/SplashTests/Tests/EnumTests.swift
@@ -48,6 +48,16 @@ final class EnumTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testUsingEnumInSubscript() {
+        let components = highlighter.highlight("dictionary[.key]")
+
+        XCTAssertEqual(components, [
+            .plainText("dictionary[."),
+            .token("key", .dotAccess),
+            .plainText("]")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -58,7 +68,8 @@ extension EnumTests {
         return [
             ("testEnumDotSyntaxInAssignment", testEnumDotSyntaxInAssignment),
             ("testEnumDotSyntaxAsArgument", testEnumDotSyntaxAsArgument),
-            ("testEnumDotSyntaxWithAssociatedValue", testEnumDotSyntaxWithAssociatedValue)
+            ("testEnumDotSyntaxWithAssociatedValue", testEnumDotSyntaxWithAssociatedValue),
+            ("testUsingEnumInSubscript", testUsingEnumInSubscript)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes highlighting when an enum is used as a dictionary key, like this:

```
let value = dictionary[.key]
```