### PR TITLE
Correctly highlight subscript declarations

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,7 +47,7 @@ private extension SwiftGrammar {
         "super", "self", "set", "true", "false", "nil",
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
-        "lazy"
+        "lazy", "subscript"
     ]
 
     struct PreprocessingRule: SyntaxRule {
@@ -159,6 +159,12 @@ private extension SwiftGrammar {
 
         func matches(_ segment: Segment) -> Bool {
             guard segment.tokens.current.startsWithLetter else {
+                return false
+            }
+
+            // Subscripting is a bit of an edge case, since it's the only keyword
+            // that looks like a function call, so we need to handle it explicitly
+            guard segment.tokens.current != "subscript" else {
                 return false
             }
 

--- a/Tests/SplashTests/Core/TestCaseVerifier.swift
+++ b/Tests/SplashTests/Core/TestCaseVerifier.swift
@@ -22,7 +22,11 @@ struct TestCaseVerifier<Case: XCTestCase> {
             }
 
             guard testNames.contains(name) else {
-                XCTFail("Test case \(Case.self) does not include test \(name) on Linux")
+                XCTFail("""
+                Test case \(Case.self) does not include test \(name) on Linux.
+                Please add it to the test case's 'allTests' array.
+                """)
+
                 return false
             }
         }

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -424,6 +424,43 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testSubscriptDeclaration() {
+        let components = highlighter.highlight("""
+        extension Collection {
+            subscript(key: Key) -> Value? { return nil }
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("extension", .keyword),
+            .whitespace(" "),
+            .token("Collection", .type),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("subscript", .keyword),
+            .plainText("(key:"),
+            .whitespace(" "),
+            .token("Key", .type),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Value", .type),
+            .plainText("?"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("return", .keyword),
+            .whitespace(" "),
+            .token("nil", .keyword),
+            .whitespace(" "),
+            .plainText("}"),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -449,7 +486,8 @@ extension DeclarationTests {
             ("testLazyPropertyDeclaration", testLazyPropertyDeclaration),
             ("testGenericPropertyDeclaration", testGenericPropertyDeclaration),
             ("testPropertyDeclarationWithWillSet", testPropertyDeclarationWithWillSet),
-            ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet)
+            ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),
+            ("testSubscriptDeclaration", testSubscriptDeclaration)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes syntax highlighting when declaring a subscript:

```
struct MyStruct {
	subscript(key: Key) -> Value? {
		…
	}
}
```