### PR TITLE
Highlight ‘self’ as keyword when used to refer to a type

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -276,6 +276,10 @@ private extension SwiftGrammar {
                 return false
             }
 
+            guard segment.tokens.current != "self" else {
+                return false
+            }
+
             return segment.tokens.onSameLine.first != "import"
         }
     }
@@ -292,14 +296,12 @@ private extension SwiftGrammar {
                 return false
             }
 
-            guard !segment.prefixedByDotAccess else {
+            guard segment.tokens.current != "self" else {
                 return false
             }
 
-            if let previousToken = segment.tokens.previous {
-                guard !keywords.contains(previousToken) else {
-                    return false
-                }
+            guard !segment.prefixedByDotAccess else {
+                return false
             }
 
             return segment.tokens.onSameLine.first != "import"

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -88,6 +88,19 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testPassingTypeToFunction() {
+        let components = highlighter.highlight("call(String.self)")
+
+        XCTAssertEqual(components, [
+            .token("call", .call),
+            .plainText("("),
+            .token("String", .type),
+            .plainText("."),
+            .token("self", .keyword),
+            .plainText(")")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -101,7 +114,8 @@ extension FunctionCallTests {
             ("testExplicitInitializerCall", testExplicitInitializerCall),
             ("testAccessingPropertyAfterFunctionCallWithoutArguments", testAccessingPropertyAfterFunctionCallWithoutArguments),
             ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments),
-            ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType)
+            ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType),
+            ("testPassingTypeToFunction", testPassingTypeToFunction)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes syntax highlighting when using `.self` to refer to a type.