### PR TITLE
Don’t highlight keywords when used as a parameter label

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -213,6 +213,15 @@ private extension SwiftGrammar {
                 }
             }
 
+            if let previousToken = segment.tokens.previous {
+                // Don't highlight most keywords when used as a parameter label
+                if !segment.tokens.current.isAny(of: "_", "self", "let", "var") {
+                    guard !previousToken.isAny(of: "(", ",") else {
+                        return false
+                    }
+                }
+            }
+
             return keywords.contains(segment.tokens.current)
         }
     }

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -73,6 +73,21 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithKeywordArgumentLabel() {
+        let components = highlighter.highlight("func a(for b: B)")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("a(for"),
+            .whitespace(" "),
+            .plainText("b:"),
+            .whitespace(" "),
+            .token("B", .type),
+            .plainText(")")
+        ])
+    }
+
     func testGenericFunctionDeclarationWithoutConstraints() {
         let components = highlighter.highlight("func hello<A, B>(a: A, b: B)")
 
@@ -473,6 +488,7 @@ extension DeclarationTests {
             ("testRequiredFunctionDeclaration", testRequiredFunctionDeclaration),
             ("testPublicFunctionDeclarationWithDocumentationEndingWithDot", testPublicFunctionDeclarationWithDocumentationEndingWithDot),
             ("testFunctionDeclarationWithEmptyExternalLabel", testFunctionDeclarationWithEmptyExternalLabel),
+            ("testFunctionDeclarationWithKeywordArgumentLabel", testFunctionDeclarationWithKeywordArgumentLabel),
             ("testGenericFunctionDeclarationWithoutConstraints", testGenericFunctionDeclarationWithoutConstraints),
             ("testGenericFunctionDeclarationWithSingleConstraint", testGenericFunctionDeclarationWithSingleConstraint),
             ("testGenericFunctionDeclarationWithMultipleConstraints", testGenericFunctionDeclarationWithMultipleConstraints),


### PR DESCRIPTION
Most keywords can be used as parameter labels, such as “for” or “in”, but they shouldn’t be highlighted in that context.