### PR TITLE
added “defer” as a keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,7 +47,7 @@ private extension SwiftGrammar {
         "super", "self", "set", "true", "false", "nil",
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
-        "lazy", "subscript"
+        "lazy", "subscript", "defer"
     ]
 
     struct PreprocessingRule: SyntaxRule {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -475,6 +475,25 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
             .plainText("}")
         ])
     }
+    
+    func testDeferDeclaration() {
+        let components = highlighter.highlight("func hello() { defer {} }")
+        
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("hello()"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("defer", .keyword),
+            .whitespace(" "),
+            .plainText("{}"),
+            .whitespace(" "),
+            .plainText("}")
+            ])
+        
+    }
 
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
@@ -503,7 +522,8 @@ extension DeclarationTests {
             ("testGenericPropertyDeclaration", testGenericPropertyDeclaration),
             ("testPropertyDeclarationWithWillSet", testPropertyDeclarationWithWillSet),
             ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),
-            ("testSubscriptDeclaration", testSubscriptDeclaration)
+            ("testSubscriptDeclaration", testSubscriptDeclaration),
+            ("testDeferDeclaration", testDeferDeclaration)
         ]
     }
 }


### PR DESCRIPTION
`defer` is also a keyword. I added it as well as dedicated test case