### PR TITLE
Add support for new keywords

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,7 +47,7 @@ private extension SwiftGrammar {
         "super", "self", "set", "true", "false", "nil",
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
-        "lazy", "subscript", "defer", "inout", "while"
+        "lazy", "subscript", "defer", "inout", "while",
         "continue", "fallthrough", "repeat"
     ]
 

--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -48,7 +48,7 @@ private extension SwiftGrammar {
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
         "lazy", "subscript", "defer", "continue",
-        "fallthrough", "repeat"
+        "fallthrough", "repeat", "while"
     ]
 
     struct PreprocessingRule: SyntaxRule {

--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,7 +47,8 @@ private extension SwiftGrammar {
         "super", "self", "set", "true", "false", "nil",
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
-        "lazy", "subscript", "defer"
+        "lazy", "subscript", "defer", "continue",
+        "fallthrough", "repeat"
     ]
 
     struct PreprocessingRule: SyntaxRule {

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -134,6 +134,40 @@ final class StatementTests: SyntaxHighlighterTestCase {
             .plainText("}")
         ])
     }
+        
+    func testSwitchStatementWithFallthrough() {
+        let components = highlighter.highlight("""
+        switch variable {
+        case .one: fallthrough
+        default:
+            callB()
+        }
+        """)
+        
+        XCTAssertEqual(components, [
+            .token("switch", .keyword),
+            .whitespace(" "),
+            .plainText("variable"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n"),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .plainText("."),
+            .token("one", .dotAccess),
+            .plainText(":"),
+            .whitespace(" "),
+            .token("fallthrough", .keyword),
+            .whitespace("\n"),
+            .token("default", .keyword),
+            .plainText(":"),
+            .whitespace("\n    "),
+            .token("callB", .call),
+            .plainText("()"),
+            .whitespace("\n"),
+            .plainText("}")
+            ])
+    }
 
     func testForStatementWithStaticProperty() {
         let components = highlighter.highlight("for value in Enum.allCases { }")
@@ -153,6 +187,83 @@ final class StatementTests: SyntaxHighlighterTestCase {
             .whitespace(" "),
             .plainText("}")
         ])
+    }
+        
+    func testForStatementWithContinue() {
+        let components = highlighter.highlight("for value in Enum.allCases { continue }")
+        
+        XCTAssertEqual(components, [
+            .token("for", .keyword),
+            .whitespace(" "),
+            .plainText("value"),
+            .whitespace(" "),
+            .token("in", .keyword),
+            .whitespace(" "),
+            .token("Enum", .type),
+            .plainText("."),
+            .token("allCases", .property),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("continue",.keyword),
+            .plainText("}")
+            ])
+    }
+    
+    func testRepeatWhileStatement() {
+        let components = highlighter.highlight("""
+        var x = 5
+        repeat {
+            print(x)
+            x = x - 1
+        } while x > 1
+        """)
+        
+        XCTAssertEqual(components, [
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("x"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("5", .number),
+            .whitespace("\n"),
+            .token("repeat", .keyword),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n"),
+            .whitespace(" "),
+            .whitespace(" "),
+            .whitespace(" "),
+            .whitespace(" "),
+            .token("print", .call),
+            .plainText("(x)"),
+            .whitespace("\n"),
+            .whitespace(" "),
+            .whitespace(" "),
+            .whitespace(" "),
+            .whitespace(" "),
+            .plainText("x"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .plainText("x"),
+            .whitespace(" "),
+            .plainText("-"),
+            .whitespace(" "),
+            .token("1", .number),
+            .whitespace("\n"),
+            .plainText("}"),
+            .whitespace(" "),
+            .token("while", .keyword),
+            .whitespace(" "),
+            .plainText("x"),
+            .whitespace(" "),
+            .plainText(">"),
+            .whitespace(" "),
+            .token("1", .number)
+            ])
+        
     }
 
     func testAllTestsRunOnLinux() {

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -206,6 +206,7 @@ final class StatementTests: SyntaxHighlighterTestCase {
             .plainText("{"),
             .whitespace(" "),
             .token("continue",.keyword),
+            .whitespace(" "),
             .plainText("}")
             ])
     }
@@ -231,18 +232,10 @@ final class StatementTests: SyntaxHighlighterTestCase {
             .token("repeat", .keyword),
             .whitespace(" "),
             .plainText("{"),
-            .whitespace("\n"),
-            .whitespace(" "),
-            .whitespace(" "),
-            .whitespace(" "),
-            .whitespace(" "),
+            .whitespace("\n    "),
             .token("print", .call),
             .plainText("(x)"),
-            .whitespace("\n"),
-            .whitespace(" "),
-            .whitespace(" "),
-            .whitespace(" "),
-            .whitespace(" "),
+            .whitespace("\n    "),
             .plainText("x"),
             .whitespace(" "),
             .plainText("="),

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -279,7 +279,10 @@ extension StatementTests {
             ("testChainedIfElseStatements", testChainedIfElseStatements),
             ("testSwitchStatement", testSwitchStatement),
             ("testSwitchStatementWithAssociatedValues", testSwitchStatementWithAssociatedValues),
-            ("testForStatementWithStaticProperty", testForStatementWithStaticProperty)
+            ("testSwitchStatementWithFallthrough", testSwitchStatementWithFallthrough),
+            ("testForStatementWithStaticProperty", testForStatementWithStaticProperty),
+            ("testForStatementWithContinue", testForStatementWithContinue),
+            ("testRepeatWhileStatement", testRepeatWhileStatement)
         ]
     }
 }


### PR DESCRIPTION
This PR introduces the following keywords in SwiftGrammar:

- continue
- fallthrough
- repeat

**UPDATE:**
- while