### PR TITLE
Support multi-line comments with asterisks

### DIFF
--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -59,6 +59,30 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testMultiLineCommentWithConsecutiveAsterisks() {
+        let components = highlighter.highlight("""
+        /**
+         Splash
+         */
+        struct Foo {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("/*", .comment),
+            .token("*", .comment),
+            .whitespace("\n "),
+            .token("Splash", .comment),
+            .whitespace("\n "),
+            .token("*/", .comment),
+            .whitespace("\n"),
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Foo"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -68,7 +92,8 @@ extension CommentTests {
     static var allTests: [(String, TestClosure<CommentTests>)] {
         return [
             ("testSingleLineComment", testSingleLineComment),
-            ("testMultiLineComment", testMultiLineComment)
+            ("testMultiLineComment", testMultiLineComment),
+            ("testMultiLineCommentWithConsecutiveAsterisks", testMultiLineCommentWithConsecutiveAsterisks)
         ]
     }
 }


### PR DESCRIPTION
Add failing test to indicate failure case on multi-line comments that contain consecutive asterisks. Ironically, this was found by running one of the project's source files through Rambo's web generator. The consecutive asterisks in the copyright header appears to be breaking highlighting for the rest of the file. Looks like the solution to this lies in bolstering the logic in `CommentRule` in `SwiftGrammar.swift`.