### PR TITLE
Add support for multi asterisks comments (/**)

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -76,11 +76,14 @@ private extension SwiftGrammar {
                 return true
             }
 
-            if segment.tokens.current.isAny(of: "/*", "*/") {
+            if segment.tokens.current.isAny(of: "/*", "/**", "*/") {
                 return true
             }
+            
+            let isStandardComment = !segment.tokens.containsBalancedOccurrences(of: "/*", and: "*/")
+            let isMultiAsterixsComment = !segment.tokens.containsBalancedOccurrences(of: "/**", and: "*/")
 
-            return !segment.tokens.containsBalancedOccurrences(of: "/*", and: "*/")
+            return isStandardComment || isMultiAsterixsComment
         }
     }
 

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -58,6 +58,27 @@ final class CommentTests: SyntaxHighlighterTestCase {
             .plainText("()")
         ])
     }
+    
+    func testMultiLineCommentWithMultipleAsterixs() {
+        let components = highlighter.highlight("""
+        /**
+            Comment
+        */ call()
+        """)
+        
+        XCTAssertEqual(components, [
+            .token("/**", .comment),
+            .whitespace("\n    "),
+            .token("Comment", .comment),
+            .whitespace("\n"),
+            .token("*/", .comment),
+            .whitespace(" "),
+            .token("call", .call),
+            .plainText("()")
+            ])
+    }
+    
+    
 
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
@@ -68,7 +89,8 @@ extension CommentTests {
     static var allTests: [(String, TestClosure<CommentTests>)] {
         return [
             ("testSingleLineComment", testSingleLineComment),
-            ("testMultiLineComment", testMultiLineComment)
+            ("testMultiLineComment", testMultiLineComment),
+            ("testMultiLineCommentWithMultipleAsterixs", testMultiLineCommentWithMultipleAsterixs)
         ]
     }
 }


### PR DESCRIPTION
This PR adds support for comments in this form:

/**
    Comment here
*/

The token recognition seems to be working for the comment inside the block,
but Splash in unable to recognize code after the comment ends.

For example in
/**
        Comment
*/ call()

, it will not be able to recognize call() as a function call, but will say it is a comment instead.
I think the reason behind this is in this lines from SwiftGrammar.CommentRule:

if segment.tokens.current.isAny(of: "/*", "/**", "*/") {
        return true
 }
            
let isStandardComment = !segment.tokens.containsBalancedOccurrences(of: "/*", and: "*/")
let isMultiAsterixsComment = !segment.tokens.containsBalancedOccurrences(of: "/**", and: "*/")

return isStandardComment || isMultiAsterixsComment

But I was not able to understand the problem. Hope I can get a useful hint👍🏻