### PR TITLE
Add support for different background colors

### DIFF
--- a/Sources/Splash/Theming/Theme+Defaults.swift
+++ b/Sources/Splash/Theming/Theme+Defaults.swift
@@ -28,7 +28,12 @@ public extension Theme {
                 .property : Color(red: 0.13, green: 0.67, blue: 0.62),
                 .dotAccess : Color(red: 0.57, green: 0.7, blue: 0),
                 .preprocessing : Color(red: 0.71, green: 0.54, blue: 0)
-            ]
+            ],
+            backgroundColor: Color(
+                red: 0.098,
+                green: 0.098,
+                blue: 0.098
+            )
         )
     }
 
@@ -51,7 +56,12 @@ public extension Theme {
                 .property : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .dotAccess : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .preprocessing : Color(red: 0.896, green: 0.488, blue: 0.284)
-            ]
+            ],
+            backgroundColor: Color(
+                red: 0,
+                green: 0,
+                blue: 0
+            )
         )
     }
 
@@ -74,7 +84,12 @@ public extension Theme {
                 .property : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .dotAccess : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .preprocessing : Color(red: 0.992, green: 0.791, blue: 0.45)
-            ]
+            ],
+            backgroundColor: Color(
+                red:0.18,
+                green:0.19,
+                blue:0.20
+            )
         )
     }
 
@@ -97,7 +112,12 @@ public extension Theme {
                 .property : Color(red: 0.584, green: 0.898, blue: 0.361),
                 .dotAccess : Color(red: 0.584, green: 0.898, blue: 0.361),
                 .preprocessing : Color(red: 0.952, green: 0.526, blue: 0.229)
-            ]
+            ],
+            backgroundColor: Color(
+                red: 0.163,
+                green: 0.163,
+                blue: 0.182
+            )
         )
     }
 
@@ -120,7 +140,12 @@ public extension Theme {
                 .property : Color(red: 0.278, green: 0.415, blue: 0.593),
                 .dotAccess : Color(red: 0.278, green: 0.415, blue: 0.593),
                 .preprocessing : Color(red: 0.392, green: 0.391, blue: 0.52)
-            ]
+            ],
+            backgroundColor: Color(
+                red:1.00,
+                green:0.99,
+                blue:0.90
+            )
         )
     }
 
@@ -143,7 +168,12 @@ public extension Theme {
                 .property : Color(red: 0.267, green: 0.537, blue: 0.576),
                 .dotAccess : Color(red: 0.267, green: 0.537, blue: 0.576),
                 .preprocessing : Color(red: 0.431, green: 0.125, blue: 0.051)
-            ]
+            ],
+            backgroundColor: Color(
+                red:1.0,
+                green:1.0,
+                blue:1.0
+            )
         )
     }
 }

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -16,13 +16,16 @@ public struct Theme {
     public var font: Font
     /// What color to use for plain text (no highlighting)
     public var plainTextColor: Color
+    /// What color to use for background
+    public var backgroundColor: Color
     /// What color to use for the text's highlighted tokens
     public var tokenColors: [TokenType : Color]
 
-    public init(font: Font, plainTextColor: Color, tokenColors: [TokenType : Color]) {
+    public init(font: Font, plainTextColor: Color, tokenColors: [TokenType : Color], backgroundColor:Color = Color(white: 0.12, alpha: 1)) {
         self.font = font
         self.plainTextColor = plainTextColor
         self.tokenColors = tokenColors
+        self.backgroundColor = backgroundColor
     }
 }
 

--- a/Sources/SplashImageGen/Extensions/CommandLine+Options.swift
+++ b/Sources/SplashImageGen/Extensions/CommandLine+Options.swift
@@ -15,6 +15,7 @@ extension CommandLine {
         let outputURL: URL
         let padding: CGFloat
         let font: Font
+        let themeName:ThemeName
     }
 
     static func makeOptions() -> Options? {
@@ -28,7 +29,8 @@ extension CommandLine {
             code: arguments[1],
             outputURL: resolveOutputURL(),
             padding: CGFloat(defaults.int(forKey: "p", default: 20)),
-            font: resolveFont(from: defaults)
+            font: resolveFont(from: defaults),
+            themeName:resolveTheme(from: defaults)
         )
     }
 
@@ -45,6 +47,16 @@ extension CommandLine {
         }
 
         return Font(path: path, size: size)
+    }
+    
+    private static func resolveTheme(from defaults: UserDefaults) -> ThemeName {
+        guard let providedName = defaults.string(forKey: "t") else {
+            return .sundellsColors
+        }
+        if let themeName = ThemeName(rawValue: providedName) {
+            return themeName
+        }
+        return .sundellsColors
     }
 }
 

--- a/Sources/SplashImageGen/Extensions/ThemeName.swift
+++ b/Sources/SplashImageGen/Extensions/ThemeName.swift
@@ -1,0 +1,38 @@
+//
+//  ThemeName.swift
+//  SplashImageGen
+//
+//  Created by Maciej Gad on 23/09/2018.
+//
+
+import Foundation
+import Splash
+
+public enum ThemeName:String {
+    case sundellsColors
+    case midnight
+    case wwdc17
+    case wwdc18
+    case sunset
+    case presentation
+}
+
+
+extension ThemeName {
+    public func theme(withFont font: Splash.Font) -> Splash.Theme {
+        switch self {
+            case .sundellsColors:
+                return Theme.sundellsColors(withFont:font)
+            case .midnight:
+                return Theme.midnight(withFont:font)
+            case .wwdc17:
+                return Theme.wwdc17(withFont:font)
+            case .wwdc18:
+                return Theme.wwdc18(withFont:font)
+            case .sunset:
+                return Theme.sunset(withFont:font)
+            case .presentation:
+                return Theme.presentation(withFont:font)
+        }
+    }
+}

--- a/Sources/SplashImageGen/main.swift
+++ b/Sources/SplashImageGen/main.swift
@@ -39,8 +39,7 @@ let contextRect = CGRect(
 let context = NSGraphicsContext(size: contextRect.size)
 NSGraphicsContext.current = context
 
-let backgroundColor = NSColor(white: 0.12, alpha: 1)
-context.fill(with: backgroundColor, in: contextRect)
+context.fill(with: theme.backgroundColor, in: contextRect)
 
 string.draw(in: CGRect(
     x: options.padding,

--- a/Sources/SplashImageGen/main.swift
+++ b/Sources/SplashImageGen/main.swift
@@ -19,11 +19,13 @@ guard let options = CommandLine.makeOptions() else {
     -p The amount of padding (in pixels) to apply around the code
     -f A path to a font to use when rendering
     -s The size of text to use when rendering
+    -t Theme name (default sundellsColors)
     """)
     exit(1)
 }
 
-let theme = Theme.sundellsColors(withFont: options.font)
+let themeName = options.themeName
+let theme = themeName.theme(withFont: options.font)
 let outputFormat = AttributedStringOutputFormat(theme: theme)
 let highlighter = SyntaxHighlighter(format: outputFormat)
 let string = highlighter.highlight(options.code)


### PR DESCRIPTION
I've added support for different background colors. It is especially important when you want to generate an image using a theme with a light background.You can see the difference between this two images generated using sunset theme, before:
![before](https://user-images.githubusercontent.com/802337/45927939-d27a3480-bf3b-11e8-9e1d-00dc596dcc3a.png)
 and after:
![after](https://user-images.githubusercontent.com/802337/45927941-d73ee880-bf3b-11e8-99c6-4a3ec3800a49.png)
