### PR TITLE
Add support for different background colors

### DIFF
--- a/Sources/Splash/Theming/Theme+Defaults.swift
+++ b/Sources/Splash/Theming/Theme+Defaults.swift
@@ -28,7 +28,12 @@ public extension Theme {
                 .property : Color(red: 0.13, green: 0.67, blue: 0.62),
                 .dotAccess : Color(red: 0.57, green: 0.7, blue: 0),
                 .preprocessing : Color(red: 0.71, green: 0.54, blue: 0)
-            ]
+            ],
+            backgroundColor: Color(
+                red: 0.098,
+                green: 0.098,
+                blue: 0.098
+            )
         )
     }
 
@@ -51,7 +56,12 @@ public extension Theme {
                 .property : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .dotAccess : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .preprocessing : Color(red: 0.896, green: 0.488, blue: 0.284)
-            ]
+            ],
+            backgroundColor: Color(
+                red: 0,
+                green: 0,
+                blue: 0
+            )
         )
     }
 
@@ -74,7 +84,12 @@ public extension Theme {
                 .property : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .dotAccess : Color(red: 0.431, green: 0.714, blue: 0.533),
                 .preprocessing : Color(red: 0.992, green: 0.791, blue: 0.45)
-            ]
+            ],
+            backgroundColor: Color(
+                red:0.18,
+                green:0.19,
+                blue:0.20
+            )
         )
     }
 
@@ -97,7 +112,12 @@ public extension Theme {
                 .property : Color(red: 0.584, green: 0.898, blue: 0.361),
                 .dotAccess : Color(red: 0.584, green: 0.898, blue: 0.361),
                 .preprocessing : Color(red: 0.952, green: 0.526, blue: 0.229)
-            ]
+            ],
+            backgroundColor: Color(
+                red: 0.163,
+                green: 0.163,
+                blue: 0.182
+            )
         )
     }
 
@@ -120,7 +140,12 @@ public extension Theme {
                 .property : Color(red: 0.278, green: 0.415, blue: 0.593),
                 .dotAccess : Color(red: 0.278, green: 0.415, blue: 0.593),
                 .preprocessing : Color(red: 0.392, green: 0.391, blue: 0.52)
-            ]
+            ],
+            backgroundColor: Color(
+                red:1.00,
+                green:0.99,
+                blue:0.90
+            )
         )
     }
 
@@ -143,7 +168,12 @@ public extension Theme {
                 .property : Color(red: 0.267, green: 0.537, blue: 0.576),
                 .dotAccess : Color(red: 0.267, green: 0.537, blue: 0.576),
                 .preprocessing : Color(red: 0.431, green: 0.125, blue: 0.051)
-            ]
+            ],
+            backgroundColor: Color(
+                red:1.0,
+                green:1.0,
+                blue:1.0
+            )
         )
     }
 }

--- a/Sources/Splash/Theming/Theme+Defaults.swift
+++ b/Sources/Splash/Theming/Theme+Defaults.swift
@@ -42,9 +42,9 @@ public extension Theme {
         return Theme(
             font: font,
             plainTextColor: Color(
-                red: 1.0,
-                green: 1.0,
-                blue: 1.0
+                red: 1,
+                green: 1,
+                blue: 1
             ),
             tokenColors: [
                 .keyword : Color(red: 0.828, green: 0.095, blue: 0.583),
@@ -86,9 +86,9 @@ public extension Theme {
                 .preprocessing : Color(red: 0.992, green: 0.791, blue: 0.45)
             ],
             backgroundColor: Color(
-                red:0.18,
-                green:0.19,
-                blue:0.20
+                red: 0.18,
+                green: 0.19,
+                blue: 0.2
             )
         )
     }
@@ -98,9 +98,9 @@ public extension Theme {
         return Theme(
             font: font,
             plainTextColor: Color(
-                red: 1.0,
-                green: 1.0,
-                blue: 1.0
+                red: 1,
+                green: 1,
+                blue: 1
             ),
             tokenColors: [
                 .keyword : Color(red: 0.948, green: 0.140, blue: 0.547),
@@ -126,9 +126,9 @@ public extension Theme {
         return Theme(
             font: font,
             plainTextColor: Color(
-                red: 0.0,
-                green: 0.0,
-                blue: 0.0
+                red: 0,
+                green: 0,
+                blue: 0
             ),
             tokenColors: [
                 .keyword : Color(red: 0.161, green: 0.259, blue: 0.467),
@@ -142,9 +142,9 @@ public extension Theme {
                 .preprocessing : Color(red: 0.392, green: 0.391, blue: 0.52)
             ],
             backgroundColor: Color(
-                red:1.00,
-                green:0.99,
-                blue:0.90
+                red: 1,
+                green: 0.99,
+                blue: 0.9
             )
         )
     }
@@ -154,9 +154,9 @@ public extension Theme {
         return Theme(
             font: font,
             plainTextColor: Color(
-                red: 0.0,
-                green: 0.0,
-                blue: 0.0
+                red: 0,
+                green: 0,
+                blue: 0
             ),
             tokenColors: [
                 .keyword : Color(red: 0.706, green: 0.0, blue: 0.384),
@@ -170,9 +170,9 @@ public extension Theme {
                 .preprocessing : Color(red: 0.431, green: 0.125, blue: 0.051)
             ],
             backgroundColor: Color(
-                red:1.0,
-                green:1.0,
-                blue:1.0
+                red: 1,
+                green: 1,
+                blue: 1
             )
         )
     }

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -21,7 +21,7 @@ public struct Theme {
     /// What color to use for the text's highlighted tokens
     public var tokenColors: [TokenType : Color]
 
-    public init(font: Font, plainTextColor: Color, tokenColors: [TokenType : Color], backgroundColor:Color = Color(white: 0.12, alpha: 1)) {
+    public init(font: Font, plainTextColor: Color, tokenColors: [TokenType : Color], backgroundColor: Color = Color(white: 0.12, alpha: 1)) {
         self.font = font
         self.plainTextColor = plainTextColor
         self.tokenColors = tokenColors

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -16,7 +16,7 @@ public struct Theme {
     public var font: Font
     /// What color to use for plain text (no highlighting)
     public var plainTextColor: Color
-    /// What color to use for background
+    /// What color to use for the background
     public var backgroundColor: Color
     /// What color to use for the text's highlighted tokens
     public var tokenColors: [TokenType : Color]

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -16,13 +16,16 @@ public struct Theme {
     public var font: Font
     /// What color to use for plain text (no highlighting)
     public var plainTextColor: Color
+    /// What color to use for background
+    public var backgroundColor: Color
     /// What color to use for the text's highlighted tokens
     public var tokenColors: [TokenType : Color]
 
-    public init(font: Font, plainTextColor: Color, tokenColors: [TokenType : Color]) {
+    public init(font: Font, plainTextColor: Color, tokenColors: [TokenType : Color], backgroundColor:Color = Color(white: 0.12, alpha: 1)) {
         self.font = font
         self.plainTextColor = plainTextColor
         self.tokenColors = tokenColors
+        self.backgroundColor = backgroundColor
     }
 }
 

--- a/Sources/SplashImageGen/main.swift
+++ b/Sources/SplashImageGen/main.swift
@@ -39,8 +39,7 @@ let contextRect = CGRect(
 let context = NSGraphicsContext(size: contextRect.size)
 NSGraphicsContext.current = context
 
-let backgroundColor = NSColor(white: 0.12, alpha: 1)
-context.fill(with: backgroundColor, in: contextRect)
+context.fill(with: theme.backgroundColor, in: contextRect)
 
 string.draw(in: CGRect(
     x: options.padding,


### PR DESCRIPTION
I've added support for different background colors. It is especially important when you want to generate an image using a theme with a light background.You can see the difference between this two images generated using sunset theme, before:
![before](https://user-images.githubusercontent.com/802337/45928232-b5943000-bf40-11e8-8d09-5acef8fb0a45.png)
and after:
![after](https://user-images.githubusercontent.com/802337/45928235-b927b700-bf40-11e8-86a6-bbd6a313381f.png)
