### PR TITLE
Add (working) support for multi asterisks comments (/**)

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -76,11 +76,11 @@ private extension SwiftGrammar {
                 return true
             }
 
-            if segment.tokens.current.isAny(of: "/*", "*/") {
+            if segment.tokens.current.isAny(of: "/*", "/**", "*/") {
                 return true
             }
-
-            return !segment.tokens.containsBalancedOccurrences(of: "/*", and: "*/")
+            
+            return segment.tokens.containsMoreOccurrences(of:["/*", "/**"], than: ["*/"])
         }
     }
 

--- a/Sources/Splash/Tokenizing/Segment.swift
+++ b/Sources/Splash/Tokenizing/Segment.swift
@@ -51,4 +51,14 @@ public extension Segment.Tokens {
     func containsBalancedOccurrences(of tokenA: String, and tokenB: String) -> Bool {
         return count(of: tokenA) == count(of: tokenB)
     }
+    
+    /// Return whether a number of occurrences of the first list of tokens in a higher
+    /// than a number of occurrences of the second list.
+    /// For example, this can be used to check if a token is inside a comment block.
+    func containsMoreOccurrences(of tokensA:[String], than tokensB:[String]) -> Bool {
+        let tokenAcount = tokensA.map { count(of: $0) }.reduce(0, +)
+        let tokenBcount = tokensB.map { count(of: $0) }.reduce(0, +)
+        
+        return tokenAcount > tokenBcount
+    }
 }

--- a/Tests/SplashTests/Core/XCTAssertEqual+array.swift
+++ b/Tests/SplashTests/Core/XCTAssertEqual+array.swift
@@ -1,0 +1,66 @@
+/**
+ *  Splash
+ *  Copyright (c) John Sundell 2018
+ *  MIT license - see LICENSE.md
+ */
+
+import XCTest
+
+/**
+ This version of function XCTAssertEqual will compare each of element separately, so you will get a better error message.
+ 
+ It assumes that you provide the first list as one line variable and second as an array literal with each element on a new line:
+ 
+ ```
+ let testOutput = [true, false, false]
+ XCTAssertEqual(testOutput, [
+ true,
+ true,
+ false
+ ])
+ ```
+ 
+ - parameters:
+     - expression1: An expression of type [T], where T is Equatable.
+     - expression2: An expression of type [T], where T is Equatable.
+     - message: An optional description of the failure.
+     - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
+     - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+ */
+
+func XCTAssertEqual<T>(_ expression1: @autoclosure () throws -> [T], _ expression2: @autoclosure () throws -> [T], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T : Equatable {
+    
+    let list1 = try! expression1()
+    let list2 = try! expression2()
+    
+    let list1Count = list1.count
+    let list2Count = list2.count
+    
+    func updateLine(_ i:Int) -> UInt {
+        if i >= list2Count {
+           return line
+        }
+        return line + UInt(i+1)
+    }
+    
+    let count = max(list1Count, list2Count)
+    for i in 0..<count {
+        let value1 = list1[safe:i]
+        let value2 = list2[safe:i]
+        if value1 != nil && value2 != nil {
+            XCTAssertEqual(value1!, value2!, file: file, line: updateLine(i))
+        } else {
+            XCTAssertEqual(value1, value2, file: file, line: updateLine(i))
+        }
+    }
+}
+
+extension Collection {
+    
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Iterator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}
+
+

--- a/Tests/SplashTests/Mocks/OutputBuilderMock.swift
+++ b/Tests/SplashTests/Mocks/OutputBuilderMock.swift
@@ -34,3 +34,17 @@ extension OutputBuilderMock {
         case whitespace(String)
     }
 }
+
+
+extension OutputBuilderMock.Component: CustomDebugStringConvertible {
+    var debugDescription: String {
+        switch self {
+        case .token(let value, let type):
+            return "token(\(value), \(type))"
+        case .plainText(let value):
+            return "plainText(\(value))"
+        case .whitespace(let value):
+            return "whitespace(\(value))"
+        }
+    }
+}

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -58,6 +58,48 @@ final class CommentTests: SyntaxHighlighterTestCase {
             .plainText("()")
         ])
     }
+    
+    func testMultiLineDocumentationComment() {
+        let components = highlighter.highlight("""
+        struct Foo {}
+        /** Comment
+            Hello!
+        */ call()
+        """)
+        
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Foo"),
+            .whitespace(" "),
+            .plainText("{}"),
+            .whitespace("\n"),
+            .token("/**", .comment),
+            .whitespace(" "),
+            .token("Comment", .comment),
+            .whitespace("\n    "),
+            .token("Hello!", .comment),
+            .whitespace("\n"),
+            .token("*/", .comment),
+            .whitespace(" "),
+            .token("call", .call),
+            .plainText("()")
+            ])
+    }
+    
+    func testNotStartedComment() {
+        let components = highlighter.highlight("""
+        */ call()
+        """)
+        
+        XCTAssertEqual(components, [
+            .token("*/", .comment),
+            .whitespace(" "),
+            .token("call", .call),
+            .plainText("()")
+            ])
+    }
+    
 
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
@@ -68,7 +110,9 @@ extension CommentTests {
     static var allTests: [(String, TestClosure<CommentTests>)] {
         return [
             ("testSingleLineComment", testSingleLineComment),
-            ("testMultiLineComment", testMultiLineComment)
+            ("testMultiLineComment", testMultiLineComment),
+            ("testMultiLineDocumentationComment", testMultiLineDocumentationComment),
+            ("testNotStartedComment", testNotStartedComment)
         ]
     }
 }


### PR DESCRIPTION
This PR fixes issue with documentation comments (aka multi asterisks comments), so right now this code should be highlighted correctly: 

```swift
struct Foo {}
 /** Comment
       Hello!
*/ call()
```
it also allows highlighting in a better way malformed code where comments openings and closings are not balanced, like this: 

```swift
*/ call()
``` 
PS. I've found a little tricky to read an error message that is produced by a test XCTAssertEqual method, so I've created a new implementation that will compare each of tokens separately and then display errors on specific lines.  

So you will see something like this: 
![screenshot 2018-10-07 00 09 15](https://user-images.githubusercontent.com/802337/46576256-d12e1a80-c9c5-11e8-97d2-8211149fc88b.png)

instead of: 
![screenshot 2018-10-07 00 10 03](https://user-images.githubusercontent.com/802337/46576258-dc814600-c9c5-11e8-8fba-5bde1294c05b.png)

I hope that is not a problem that I put this together with rest of code and didn't create a separate pull request