### PR TITLE
A syntax highlighting `cat`-like application for the terminal command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,5 @@ install:
 	swift build -c release -Xswiftc -static-stdlib
 	install .build/Release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
 	install .build/Release/SplashImageGen /usr/local/bin/SplashImageGen
+	install .build/Release/SplashTerminalGen /usr/local/bin/SplashTerminalGen
 	install .build/Release/SplashTokenizer /usr/local/bin/SplashTokenizer

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
             dependencies: ["Splash"]
         ),
         .target(
+            name: "SplashTerminalGen",
+            dependencies: ["Splash"]
+        ),
+        .target(
             name: "SplashTokenizer",
             dependencies: ["Splash"]
         ),

--- a/Sources/Splash/Output/TerminalOutputFormat.swift
+++ b/Sources/Splash/Output/TerminalOutputFormat.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Output format to use to generate an encoded terminal string
+public struct TerminalOutputFormat: OutputFormat {
+    public var theme: Theme
+
+    public init(theme: Theme) {
+        self.theme = theme
+    }
+
+    public func makeBuilder() -> Builder {
+        return Builder(theme: theme)
+    }
+}
+
+public extension TerminalOutputFormat {
+    struct Builder: OutputBuilder {
+        private let theme: Theme
+        private var text = ""
+
+        fileprivate init(theme: Theme) {
+            self.theme = theme
+        }
+
+        public mutating func addToken(_ token: String, ofType type: TokenType) {
+            let color = theme.tokenColors[type] ?? Color(red: 1, green: 1, blue: 1)
+            text.append(token.colorized(with: color))
+        }
+
+        public mutating func addPlainText(_ plainText: String) {
+            text.append(plainText.colorized(with: theme.plainTextColor))
+        }
+
+        public mutating func addWhitespace(_ whitespace: String) {
+            text.append(whitespace)
+        }
+
+        public func build() -> String {
+            return text
+        }
+    }
+}
+
+private extension String {
+    func colorized(with color: Color) -> String {
+        return "\u{001B}[38;5;\(color.xtermIndex)m\(self)\u{001B}[39m"
+    }
+}
+
+// Converting from RGB to 256-color xterm
+//
+// Inspired by the explanation given in
+// https://codegolf.stackexchange.com/questions/156918/rgb-to-xterm-color-converter
+private extension Color {
+    private static let xtermDefaultColorIndex = 16
+    private static let xtermIndices = [0, 95, 135, 175, 215, 255]
+    private static let xtermTriplets: [(Int, Int, Int)] = (0 ..< 239).map {
+        let uniformValue = $0 * 10 - 2152
+        return $0 < 216 ? (xtermIndices[$0 / 36], xtermIndices[($0 % 36) / 6], xtermIndices[$0 % 6]) :
+            (uniformValue, uniformValue, uniformValue)
+    }
+
+    var xtermIndex: Int {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        getRed(&red, green: &green, blue: &blue, alpha: nil)
+
+        let manhattanDistances: [Float] = Color.xtermTriplets.map { triplet in
+            let distances = [
+                fabsf(Float(red * 255) - Float(triplet.0)),
+                fabsf(Float(green * 255) - Float(triplet.1)),
+                fabsf(Float(blue * 255) - Float(triplet.2))
+            ]
+
+            return distances.reduce(0, +)
+        }
+
+        guard
+            let lowestDistance = manhattanDistances.min(),
+            let index = manhattanDistances.lastIndex(of: lowestDistance)
+        else {
+            return Color.xtermDefaultColorIndex
+        }
+
+        return index + Color.xtermDefaultColorIndex
+    }
+}

--- a/Sources/Splash/Output/TerminalOutputFormat.swift
+++ b/Sources/Splash/Output/TerminalOutputFormat.swift
@@ -23,7 +23,7 @@ public extension TerminalOutputFormat {
         }
 
         public mutating func addToken(_ token: String, ofType type: TokenType) {
-            let color = theme.tokenColors[type] ?? Color(red: 1, green: 1, blue: 1)
+            let color = theme.tokenColors[type] ?? .white
             text.append(token.colorized(with: color))
         }
 
@@ -42,6 +42,8 @@ public extension TerminalOutputFormat {
 }
 
 private extension String {
+    // Color formatting for xterm is described in the section named "88/256 Colors" here:
+    // https://misc.flogisoft.com/bash/tip_colors_and_formatting
     func colorized(with color: Color) -> String {
         return "\u{001B}[38;5;\(color.xtermIndex)m\(self)\u{001B}[39m"
     }
@@ -51,9 +53,9 @@ private extension String {
 //
 // Inspired by the explanation given in
 // https://codegolf.stackexchange.com/questions/156918/rgb-to-xterm-color-converter
-private extension Color {
+extension Color {
     private static let xtermDefaultColorIndex = 16
-    private static let xtermColors: [(Int, Int, Int)] = (0 ..< 239).map {
+    private static let xtermColors: [(Int, Int, Int)] = (0 ... 239).map {
         let indices = [0, 95, 135, 175, 215, 255]
         let uniformValue = $0 * 10 - 2152
 
@@ -87,3 +89,16 @@ private extension Color {
         return index + Color.xtermDefaultColorIndex
     }
 }
+
+#if swift(>=4.2)
+#else
+private extension Array where Element: Equatable {
+    func lastIndex(of element: Element) -> Int? {
+        guard let index = reversed().firstIndex(of: element)?.base else {
+            return nil
+        }
+
+        return index - 1
+    }
+}
+#endif

--- a/Sources/Splash/Output/TerminalOutputFormat.swift
+++ b/Sources/Splash/Output/TerminalOutputFormat.swift
@@ -47,16 +47,17 @@ private extension String {
     }
 }
 
-// Converting from RGB to 256-color xterm
+// Converting from RGB to closest 256-color xterm value
 //
 // Inspired by the explanation given in
 // https://codegolf.stackexchange.com/questions/156918/rgb-to-xterm-color-converter
 private extension Color {
     private static let xtermDefaultColorIndex = 16
-    private static let xtermIndices = [0, 95, 135, 175, 215, 255]
-    private static let xtermTriplets: [(Int, Int, Int)] = (0 ..< 239).map {
+    private static let xtermColors: [(Int, Int, Int)] = (0 ..< 239).map {
+        let indices = [0, 95, 135, 175, 215, 255]
         let uniformValue = $0 * 10 - 2152
-        return $0 < 216 ? (xtermIndices[$0 / 36], xtermIndices[($0 % 36) / 6], xtermIndices[$0 % 6]) :
+
+        return $0 < 216 ? (indices[$0 / 36], indices[($0 % 36) / 6], indices[$0 % 6]) :
             (uniformValue, uniformValue, uniformValue)
     }
 
@@ -66,11 +67,11 @@ private extension Color {
         var blue: CGFloat = 0
         getRed(&red, green: &green, blue: &blue, alpha: nil)
 
-        let manhattanDistances: [Float] = Color.xtermTriplets.map { triplet in
+        let manhattanDistances: [Float] = Color.xtermColors.map { (r, g, b) in
             let distances = [
-                fabsf(Float(red * 255) - Float(triplet.0)),
-                fabsf(Float(green * 255) - Float(triplet.1)),
-                fabsf(Float(blue * 255) - Float(triplet.2))
+                fabsf(Float(red * 255) - Float(r)),
+                fabsf(Float(green * 255) - Float(g)),
+                fabsf(Float(blue * 255) - Float(b))
             ]
 
             return distances.reduce(0, +)

--- a/Sources/SplashTerminalGen/main.swift
+++ b/Sources/SplashTerminalGen/main.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Splash
+
+guard CommandLine.arguments.count > 1 else {
+    print("⚠️  Please supply the file to concatenate")
+    exit(1)
+}
+
+let file = CommandLine.arguments[1]
+let theme = Theme.midnight(withFont: Font(size: 17))
+let highlighter = SyntaxHighlighter(format: TerminalOutputFormat(theme: theme))
+
+do {
+    let code = try String(contentsOfFile: file)
+    print(highlighter.highlight(code))
+}
+catch {
+    print("⚠️  Could not read from \(file)")
+    exit(1)
+}

--- a/Tests/SplashTests/Tests/TerminalOutputFormatTests.swift
+++ b/Tests/SplashTests/Tests/TerminalOutputFormatTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+@testable import Splash
+
+final class TerminalOutputFormatTests: SplashTestCase {
+    func testEscapedHighlightingOutput() {
+        let theme = Theme.midnight(withFont: Font(size: 17))
+        let formatter = TerminalOutputFormat(theme: theme)
+        let highlighter = SyntaxHighlighter(format: formatter)
+
+        let terminalOutput = highlighter.highlight("static let image = UIImage(named: \"splash\")!")
+
+        XCTAssertEqual(terminalOutput, """
+        \u{001B}[38;5;162mstatic\u{001B}[39m \u{001B}[38;5;162mlet\u{001B}[39m \u{001B}[38;5;231mimage\u{001B}[39m \u{001B}[38;5;231m=\u{001B}[39m \u{001B}[38;5;48mUIImage\u{001B}[39m\u{001B}[38;5;231m(named:\u{001B}[39m \u{001B}[38;5;197m"splash"\u{001B}[39m\u{001B}[38;5;231m)!\u{001B}[39m
+        """)
+    }
+
+    // Xterm color test vectors
+    //
+    //  R   G   B     Xterm
+    // --------------------
+    //   0   0   0 ==>  16
+    //  95 135   0 ==>  64
+    // 255 255 255 ==> 231
+    // 238 238 238 ==> 255
+    //
+    //  90 133 140 ==>  66
+    // 218 215 216 ==> 188
+    // 175 177 178 ==> 249
+    //
+    // 175   0 155 ==> 127
+    //  75  75  75 ==> 239
+    //  23  23  23 ==> 234
+    // 115 155 235 ==> 111
+    func testColorIndices() {
+        let rgbColors = [
+            (  0,   0,   0),
+            ( 95, 135,   0),
+            (255, 255, 255),
+            (238, 238, 238),
+            ( 90, 133, 140),
+            (218, 215, 216),
+            (175, 177, 178),
+            (175,   0, 155),
+            ( 75,  75,  75),
+            ( 23,  23,  23),
+            (115, 155, 235),
+        ]
+
+        let xtermColors = [
+            16, 64, 231, 255, 66, 188, 249, 127, 239, 234, 111
+        ]
+
+        zip(rgbColors, xtermColors).forEach {
+            let color = Color(red: CGFloat($0.0) / 255.0, green: CGFloat($0.1) / 255.0, blue: CGFloat($0.2) / 255.0, alpha: 1.0)
+            XCTAssertEqual(color.xtermIndex, $1)
+        }
+    }
+
+    func testAllTestsRunOnLinux() {
+        XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
+    }
+}
+
+extension TerminalOutputFormatTests {
+    static var allTests: [(String, TestClosure<TerminalOutputFormatTests>)] {
+        return [
+            ("testEscapedHighlightingOutput", testEscapedHighlightingOutput),
+            ("testColorIndices", testColorIndices)
+        ]
+    }
+}


### PR DESCRIPTION
Hi John,

Here's my attempt at adding a Splash-ed `cat`-like application for the `Terminal.app`

**To do & still up for discussion:**
*Not a cat*
A true `cat` allows multiple files as inputs and concatenates all of them at once, and it also allows for free text as input. At the moment this only supports accepting a single file as input.

*Themes*
I'd like to support specifying a theme in the command line with e.g `--theme wwdc17` but I think a real solution to that would mean having to create something with `RawRepresentable` (enums or otherwise) that would map the command line string to the defaults in `Theme+Defaults.swift`. That would be a large refactor of your theme code, though, and I don't want to do that on this PR.

*Tests*
~Still to do before merging.~

The biggest bit of logic that needs testing is the value returned as the `xtermIndex` for a given `Color`, however this should be implemented in a `private extension` in `TerminalOutputFormat.swift` rather than an internal extension, so it's probably not something that should be testable. However, it governs the translation from theme colours to xterm colours and as such is the most important part of the formatter.


*Copyrights*
I don't know what your preference for this is, just let me know.



**Notes**
Terminal.app only supports 256 colours, this is a restriction of `xterm`, so the colours displayed only approximate to the theme colours. They can't match exactly.

And because it's Splash+Cat, I have an alias to call it `splat` 😃 but I don't want to ruin your pre-defined naming, so officially it's `SplashTerminalGen`

Any omissions or general not-clear-ness, just let me know. I don't make PRs very often.