### PR TITLE
Add support for indirect enums

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -48,7 +48,7 @@ private extension SwiftGrammar {
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
         "lazy", "subscript", "defer", "inout", "while",
-        "continue", "fallthrough", "repeat"
+        "continue", "fallthrough", "repeat", "indirect"
     ]
 
     struct PreprocessingRule: SyntaxRule {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -520,6 +520,39 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testIndirectEnumDeclaration() {
+        let components = highlighter.highlight("""
+        indirect enum Content {
+            case single(String)
+            case collection([Content])
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("indirect", .keyword),
+            .whitespace(" "),
+            .token("enum", .keyword),
+            .whitespace(" "),
+            .plainText("Content"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .plainText("single("),
+            .token("String", .type),
+            .plainText(")"),
+            .whitespace("\n    "),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .plainText("collection(["),
+            .token("Content", .type),
+            .plainText("])"),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -549,7 +582,8 @@ extension DeclarationTests {
             ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),
             ("testSubscriptDeclaration", testSubscriptDeclaration),
             ("testDeferDeclaration", testDeferDeclaration),
-            ("testFunctionDeclarationWithInOutParameter", testFunctionDeclarationWithInOutParameter)
+            ("testFunctionDeclarationWithInOutParameter", testFunctionDeclarationWithInOutParameter),
+            ("testIndirectEnumDeclaration", testIndirectEnumDeclaration)
         ]
     }
 }


### PR DESCRIPTION
This patch makes Splash correctly highlight `indirect` enums. The keyword was missing from the grammar definition.