### PR TITLE
Bump Swift version to 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: generic
 sudo: required
 dist: trusty
 env:
-    - SWIFT_VERSION=4.1
+    - SWIFT_VERSION=4.2
 install:
     - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 script:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:4.2
 
 /**
  *  Splash


### PR DESCRIPTION
This change makes Splash use Swift version `4.2`.