### PR TITLE
Don’t treat .init() as an enum

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -286,7 +286,7 @@ private extension SwiftGrammar {
                 return false
             }
 
-            guard segment.tokens.current != "self" else {
+            guard !segment.tokens.current.isAny(of: "self", "init") else {
                 return false
             }
 

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -55,6 +55,24 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testDotSyntaxInitializerCall() {
+        let components = highlighter.highlight("let string: String = .init()")
+
+        XCTAssertEqual(components, [
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("string:"),
+            .whitespace(" "),
+            .token("String", .type),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .plainText("."),
+            .token("init", .keyword),
+            .plainText("()")
+        ])
+    }
+
     func testAccessingPropertyAfterFunctionCallWithoutArguments() {
         let components = highlighter.highlight("call().property")
 
@@ -112,6 +130,7 @@ extension FunctionCallTests {
             ("testFunctionCallWithIntegers", testFunctionCallWithIntegers),
             ("testImplicitInitializerCall", testImplicitInitializerCall),
             ("testExplicitInitializerCall", testExplicitInitializerCall),
+            ("testDotSyntaxInitializerCall", testDotSyntaxInitializerCall),
             ("testAccessingPropertyAfterFunctionCallWithoutArguments", testAccessingPropertyAfterFunctionCallWithoutArguments),
             ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments),
             ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType),


### PR DESCRIPTION
This change adds a special condition not to treat `.init()` as an enum (or any other kind of dot access), just like we previously had for `self`.