### PR TITLE
Don’t treat keywords used as function names as keywords

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -221,6 +221,10 @@ private extension SwiftGrammar {
                         return false
                     }
                 }
+
+                guard !segment.tokens.previous.isAny(of: "func", "`") else {
+                    return false
+                }
             }
 
             return keywords.contains(segment.tokens.current)

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -520,6 +520,50 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithNonEscapedKeywordAsName() {
+        let components = highlighter.highlight("func get() -> Int { return 7 }")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("get()"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Int", .type),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("return", .keyword),
+            .whitespace(" "),
+            .token("7", .number),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
+    func testFunctionDeclarationWithEscapedKeywordAsName() {
+        let components = highlighter.highlight("func `public`() -> Int { return 7 }")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("`public`()"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Int", .type),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("return", .keyword),
+            .whitespace(" "),
+            .token("7", .number),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testIndirectEnumDeclaration() {
         let components = highlighter.highlight("""
         indirect enum Content {
@@ -583,6 +627,8 @@ extension DeclarationTests {
             ("testSubscriptDeclaration", testSubscriptDeclaration),
             ("testDeferDeclaration", testDeferDeclaration),
             ("testFunctionDeclarationWithInOutParameter", testFunctionDeclarationWithInOutParameter),
+            ("testFunctionDeclarationWithNonEscapedKeywordAsName", testFunctionDeclarationWithNonEscapedKeywordAsName),
+            ("testFunctionDeclarationWithEscapedKeywordAsName", testFunctionDeclarationWithEscapedKeywordAsName),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration)
         ]
     }


### PR DESCRIPTION
Swift enables the use of keywords as function names, and we want those to be treated as plain text (like other function names) rather than as keywords. Some keywords require escaping using back-ticks, and this patch accounts for both of those variations.