### PR TITLE
Correctly highlight Bools passed as unnamed function arguments

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -216,7 +216,7 @@ private extension SwiftGrammar {
 
             if let previousToken = segment.tokens.previous {
                 // Don't highlight most keywords when used as a parameter label
-                if !segment.tokens.current.isAny(of: "_", "self", "let", "var") {
+                if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false") {
                     guard !previousToken.isAny(of: "(", ",") else {
                         return false
                     }

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -119,6 +119,17 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testPassingBoolToUnnamedArgument() {
+        let components = highlighter.highlight("setCachingEnabled(true)")
+
+        XCTAssertEqual(components, [
+            .token("setCachingEnabled", .call),
+            .plainText("("),
+            .token("true", .keyword),
+            .plainText(")")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -134,7 +145,8 @@ extension FunctionCallTests {
             ("testAccessingPropertyAfterFunctionCallWithoutArguments", testAccessingPropertyAfterFunctionCallWithoutArguments),
             ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments),
             ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType),
-            ("testPassingTypeToFunction", testPassingTypeToFunction)
+            ("testPassingTypeToFunction", testPassingTypeToFunction),
+            ("testPassingBoolToUnnamedArgument", testPassingBoolToUnnamedArgument)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes highlighting of `Bool` values passed as arguments that don’t have an external parameter label.