### PR TITLE
Correctly highlight associated types

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -236,7 +236,8 @@ private extension SwiftGrammar {
 
         private let declarationKeywords: Set<String> = [
             "class", "struct", "enum", "func",
-            "protocol", "typealias", "import"
+            "protocol", "typealias", "import",
+            "associatedtype"
         ]
 
         func matches(_ segment: Segment) -> Bool {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -291,6 +291,37 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testProtocolDeclarationWithAssociatedTypes() {
+        let components = highlighter.highlight("""
+        protocol Task {
+            associatedtype Input
+            associatedtype Error: Swift.Error
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("protocol", .keyword),
+            .whitespace(" "),
+            .plainText("Task"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("associatedtype", .keyword),
+            .whitespace(" "),
+            .plainText("Input"),
+            .whitespace("\n    "),
+            .token("associatedtype", .keyword),
+            .whitespace(" "),
+            .plainText("Error:"),
+            .whitespace(" "),
+            .token("Swift", .type),
+            .plainText("."),
+            .token("Error", .type),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testExtensionDeclaration() {
         let components = highlighter.highlight("extension UIViewController { }")
 
@@ -636,6 +667,7 @@ extension DeclarationTests {
             ("testClassDeclarationWithMultipleProtocolConformances", testClassDeclarationWithMultipleProtocolConformances),
             ("testSubclassDeclaration", testSubclassDeclaration),
             ("testProtocolDeclaration", testProtocolDeclaration),
+            ("testProtocolDeclarationWithAssociatedTypes", testProtocolDeclarationWithAssociatedTypes),
             ("testExtensionDeclaration", testExtensionDeclaration),
             ("testExtensionDeclarationWithConstraint", testExtensionDeclarationWithConstraint),
             ("testLazyPropertyDeclaration", testLazyPropertyDeclaration),


### PR DESCRIPTION
This patch makes Splash correctly highlight associated types within protocol declarations. Like other declarations, typed declared using the `associatedtype` keyword should not be highlighted.