### PR TITLE
Add special case for `XCTAssert` family of functions

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -256,6 +256,13 @@ private extension SwiftGrammar {
                 return false
             }
 
+            // The XCTAssert family of functions is a bit of an edge case,
+            // since they start with capital letters. Since they are so
+            // commonly used, we'll add a special case for them here:
+            guard !segment.tokens.current.starts(with: "XCTAssert") else {
+                return false
+            }
+
             // In a generic declaration, only highlight constraints
             if segment.tokens.previous.isAny(of: "<", ",") {
                 var foundOpeningBracket = false

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -130,6 +130,15 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testXCTAssertCalls() {
+        let components = highlighter.highlight("XCTAssertTrue(variable)")
+
+        XCTAssertEqual(components, [
+            .token("XCTAssertTrue", .call),
+            .plainText("(variable)")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -146,7 +155,8 @@ extension FunctionCallTests {
             ("testAccessingPropertyAfterFunctionCallWithArguments", testAccessingPropertyAfterFunctionCallWithArguments),
             ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType),
             ("testPassingTypeToFunction", testPassingTypeToFunction),
-            ("testPassingBoolToUnnamedArgument", testPassingBoolToUnnamedArgument)
+            ("testPassingBoolToUnnamedArgument", testPassingBoolToUnnamedArgument),
+            ("testXCTAssertCalls", testXCTAssertCalls)
         ]
     }
 }


### PR DESCRIPTION
Normally, we don’t want Splash to contain too many special cases for individual symbol names — but the `XCTAssert` family of functions are so common that it warrants it. The problem is that Splash would currently highlight those functions as types, since they are capitalized, which has now been changed to function calls instead.