### PR TITLE
Support the deinit keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,7 +47,8 @@ private extension SwiftGrammar {
         "override", "where", "_", "default", "break",
         "#selector", "required", "willSet", "didSet",
         "lazy", "subscript", "defer", "inout", "while",
-        "continue", "fallthrough", "repeat", "indirect"
+        "continue", "fallthrough", "repeat", "indirect",
+        "deinit"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -221,6 +221,24 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testClassDeclarationWithDeinit() {
+        let components = highlighter.highlight("class Foo { deinit {} }")
+
+        XCTAssertEqual(components, [
+            .token("class", .keyword),
+            .whitespace(" "),
+            .plainText("Foo"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("deinit", .keyword),
+            .whitespace(" "),
+            .plainText("{}"),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testClassDeclarationWithMultipleProtocolConformances() {
         let components = highlighter.highlight("class MyClass: ProtocolA, ProtocolB {}")
 
@@ -690,6 +708,7 @@ extension DeclarationTests {
             ("testGenericStructDeclaration", testGenericStructDeclaration),
             ("testClassDeclaration", testClassDeclaration),
             ("testCompactClassDeclarationWithInitializer", testCompactClassDeclarationWithInitializer),
+            ("testClassDeclarationWithDeinit", testClassDeclarationWithDeinit),
             ("testClassDeclarationWithMultipleProtocolConformances", testClassDeclarationWithMultipleProtocolConformances),
             ("testSubclassDeclaration", testSubclassDeclaration),
             ("testProtocolDeclaration", testProtocolDeclaration),


### PR DESCRIPTION
This patch makes Splash correctly highlight the `deinit` keyword.