### PR TITLE
Support switch statements with nil pattern matching

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -221,6 +221,15 @@ private extension SwiftGrammar {
 
         func matches(_ segment: Segment) -> Bool {
             if segment.tokens.next == ":" {
+                // Nil pattern matching inside of a switch statement case
+                if segment.tokens.current == "nil" {
+                    guard let previousToken = segment.tokens.previous else {
+                        return false
+                    }
+
+                    return previousToken.isAny(of: "case", ",")
+                }
+
                 guard segment.tokens.current == "default" else {
                     return false
                 }

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -202,6 +202,45 @@ final class StatementTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testSwitchStatementWithOptional() {
+        let components = highlighter.highlight("""
+        switch anOptional {
+        case nil: break
+        case "value"?: break
+        default: break
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("switch", .keyword),
+            .whitespace(" "),
+            .plainText("anOptional"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n"),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .token("nil", .keyword),
+            .plainText(":"),
+            .whitespace(" "),
+            .token("break", .keyword),
+            .whitespace("\n"),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .token("\"value\"", .string),
+            .plainText("?:"),
+            .whitespace(" "),
+            .token("break", .keyword),
+            .whitespace("\n"),
+            .token("default", .keyword),
+            .plainText(":"),
+            .whitespace(" "),
+            .token("break", .keyword),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testForStatementWithStaticProperty() {
         let components = highlighter.highlight("for value in Enum.allCases { }")
 
@@ -306,6 +345,7 @@ extension StatementTests {
             ("testSwitchStatementWithAssociatedValues", testSwitchStatementWithAssociatedValues),
             ("testSwitchStatementWithFallthrough", testSwitchStatementWithFallthrough),
             ("testSwitchStatementWithTypePatternMatching", testSwitchStatementWithTypePatternMatching),
+            ("testSwitchStatementWithOptional", testSwitchStatementWithOptional),
             ("testForStatementWithStaticProperty", testForStatementWithStaticProperty),
             ("testForStatementWithContinue", testForStatementWithContinue),
             ("testRepeatWhileStatement", testRepeatWhileStatement)


### PR DESCRIPTION
This change adds support for highlighting `nil` when it occurs inside of a `switch` statement’s `case`.