### PR TITLE
Support function argument pre-processors

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -48,7 +48,7 @@ private extension SwiftGrammar {
         "#selector", "required", "willSet", "didSet",
         "lazy", "subscript", "defer", "inout", "while",
         "continue", "fallthrough", "repeat", "indirect",
-        "deinit", "is"
+        "deinit", "is", "#file", "#line", "#function"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -656,6 +656,41 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithPreProcessors() {
+        let components = highlighter.highlight("""
+        func log(_ file: StaticString = #file, _ function: StaticString = #function) {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("log("),
+            .token("_", .keyword),
+            .whitespace(" "),
+            .plainText("file:"),
+            .whitespace(" "),
+            .token("StaticString", .type),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("#file", .keyword),
+            .plainText(","),
+            .whitespace(" "),
+            .token("_", .keyword),
+            .whitespace(" "),
+            .plainText("function:"),
+            .whitespace(" "),
+            .token("StaticString", .type),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("#function", .keyword),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testIndirectEnumDeclaration() {
         let components = highlighter.highlight("""
         indirect enum Content {
@@ -725,6 +760,7 @@ extension DeclarationTests {
             ("testFunctionDeclarationWithInOutParameter", testFunctionDeclarationWithInOutParameter),
             ("testFunctionDeclarationWithNonEscapedKeywordAsName", testFunctionDeclarationWithNonEscapedKeywordAsName),
             ("testFunctionDeclarationWithEscapedKeywordAsName", testFunctionDeclarationWithEscapedKeywordAsName),
+            ("testFunctionDeclarationWithPreProcessors", testFunctionDeclarationWithPreProcessors),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration)
         ]
     }


### PR DESCRIPTION
This change adds support for three pre-processors that can appear in function delcarations: `#file`, `#line` and `#function`. They’re not highlighted as pre-processors, but rather as keywords, to match the way Xcode treats them.