### PR TITLE
HTMLOutputFormat: Merge same-type tokens along with whitespace

### DIFF
--- a/Sources/Splash/Output/OutputBuilder.swift
+++ b/Sources/Splash/Output/OutputBuilder.swift
@@ -21,5 +21,5 @@ public protocol OutputBuilder {
     /// Add some whitespace to the builder
     mutating func addWhitespace(_ whitespace: String)
     /// Build the final output based on the builder's current state
-    func build() -> Output
+    mutating func build() -> Output
 }

--- a/Tests/SplashTests/Tests/HTMLOutputFormatTests.swift
+++ b/Tests/SplashTests/Tests/HTMLOutputFormatTests.swift
@@ -10,11 +10,33 @@ final class HTMLOutputFormatTests: SplashTestCase {
         highlighter = SyntaxHighlighter(format: HTMLOutputFormat())
     }
 
+    func testBasicGeneration() {
+        let html = highlighter.highlight("""
+        public struct Test: SomeProtocol {
+            func hello() -> Int { return 7 }
+        }
+        """)
+
+        XCTAssertEqual(html, """
+        <span class="keyword">public struct</span> Test: <span class="type">SomeProtocol</span> {
+            <span class="keyword">func</span> hello() -&gt; <span class="type">Int</span> { <span class="keyword">return</span> <span class="number">7</span> }
+        }
+        """)
+    }
+
     func testStrippingGreaterAndLessThanCharactersFromOutput() {
         let html = highlighter.highlight("Array<String>")
 
         XCTAssertEqual(html, """
         <span class="type">Array</span>&lt;<span class="type">String</span>&gt;
+        """)
+    }
+
+    func testCommentMerging() {
+        let html = highlighter.highlight("// Hey I'm a comment!")
+
+        XCTAssertEqual(html, """
+        <span class="comment">// Hey I'm a comment!</span>
         """)
     }
 
@@ -26,7 +48,9 @@ final class HTMLOutputFormatTests: SplashTestCase {
 extension HTMLOutputFormatTests {
     static var allTests: [(String, TestClosure<HTMLOutputFormatTests>)] {
         return [
-            ("testStrippingGreaterAndLessThanCharactersFromOutput", testStrippingGreaterAndLessThanCharactersFromOutput)
+            ("testBasicGeneration", testBasicGeneration),
+            ("testStrippingGreaterAndLessThanCharactersFromOutput", testStrippingGreaterAndLessThanCharactersFromOutput),
+            ("testCommentMerging", testCommentMerging)
         ]
     }
 }


### PR DESCRIPTION
This change makes Splash merge tokens of the same type (along with any whitespace in between them) when generating HTML. The result is much smaller HTML, since less tags have to be used to produce the same result.

This was most obvious with comment highlighting, for example, this comment:

```swift
// Hello I’m a comment
```

Would generate 5 different <span class="comment"></span> elements. Now it’s just one! 🎉