### PR TITLE
Improve support for multi-line comments

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -80,11 +80,12 @@ private extension SwiftGrammar {
                 return true
             }
 
-            if segment.tokens.current.isAny(of: "/*", "*/") {
+            if segment.tokens.current.isAny(of: "/*", "/**", "*/") {
                 return true
             }
 
-            return !segment.tokens.containsBalancedOccurrences(of: "/*", and: "*/")
+            let multiLineStartCount = segment.tokens.count(of: "/*") + segment.tokens.count(of: "/**")
+            return multiLineStartCount != segment.tokens.count(of: "*/")
         }
     }
 

--- a/Sources/Splash/Tokenizing/Segment.swift
+++ b/Sources/Splash/Tokenizing/Segment.swift
@@ -45,10 +45,4 @@ public extension Segment.Tokens {
     func count(of token: String) -> Int {
         return counts[token] ?? 0
     }
-
-    /// Return whether an equal number of occurrences have been found of two tokens.
-    /// For example, this can be used to check if a token is encapsulated by parenthesis.
-    func containsBalancedOccurrences(of tokenA: String, and tokenB: String) -> Bool {
-        return count(of: tokenA) == count(of: tokenB)
-    }
 }

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -59,6 +59,59 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testMultiLineCommentWithDoubleAsterisks() {
+        let components = highlighter.highlight("""
+        struct Foo {}
+        /** Comment
+            Hello!
+        */ call()
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Foo"),
+            .whitespace(" "),
+            .plainText("{}"),
+            .whitespace("\n"),
+            .token("/**", .comment),
+            .whitespace(" "),
+            .token("Comment", .comment),
+            .whitespace("\n    "),
+            .token("Hello!", .comment),
+            .whitespace("\n"),
+            .token("*/", .comment),
+            .whitespace(" "),
+            .token("call", .call),
+            .plainText("()")
+        ])
+    }
+
+    func testMutliLineDocumentationComment() {
+        let components = highlighter.highlight("""
+        /**
+         *  Documentation
+         */
+        class MyClass {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("/**", .comment),
+            .whitespace("\n "),
+            .token("*", .comment),
+            .whitespace("  "),
+            .token("Documentation", .comment),
+            .whitespace("\n "),
+            .token("*/", .comment),
+            .whitespace("\n"),
+            .token("class", .keyword),
+            .whitespace(" "),
+            .plainText("MyClass"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -68,7 +121,9 @@ extension CommentTests {
     static var allTests: [(String, TestClosure<CommentTests>)] {
         return [
             ("testSingleLineComment", testSingleLineComment),
-            ("testMultiLineComment", testMultiLineComment)
+            ("testMultiLineComment", testMultiLineComment),
+            ("testMultiLineCommentWithDoubleAsterisks", testMultiLineCommentWithDoubleAsterisks),
+            ("testMutliLineDocumentationComment", testMutliLineDocumentationComment)
         ]
     }
 }


### PR DESCRIPTION
This change enables Splash to highlight multi-line comments that begin with two asterisks, rather than just one. A test has also been added to verify that documentation-style multi-line comments with an asterisk on each line are also highlighted correctly.

It also removes the `containsBalancedOccurrences` API, as it was only used by the comments rule, and would now become unused with this change.