### PR TITLE
adding support for "dynamic" keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -48,7 +48,8 @@ private extension SwiftGrammar {
         "#selector", "required", "willSet", "didSet",
         "lazy", "subscript", "defer", "inout", "while",
         "continue", "fallthrough", "repeat", "indirect",
-        "deinit", "is", "#file", "#line", "#function"
+        "deinit", "is", "#file", "#line", "#function",
+        "dynamic"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -409,6 +409,37 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
             .plainText("}")
         ])
     }
+    
+    func testDynamicPropertyDeclaration() {
+        let components = highlighter.highlight("""
+        class Hello {
+            @objc dynamic var property = 0
+        }
+        """)
+        
+        XCTAssertEqual(components, [
+            .token("class", .keyword),
+            .whitespace(" "),
+            .plainText("Hello"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("@objc", .keyword),
+            .whitespace(" "),
+            .token("dynamic", .keyword),
+            .whitespace(" "),
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("property"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("0", .number),
+            .whitespace("\n"),
+            .plainText("}")
+            ])
+    }
+
 
     func testGenericPropertyDeclaration() {
         let components = highlighter.highlight("class Hello { var array: Array<String> = [] }")

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -782,6 +782,7 @@ extension DeclarationTests {
             ("testExtensionDeclaration", testExtensionDeclaration),
             ("testExtensionDeclarationWithConstraint", testExtensionDeclarationWithConstraint),
             ("testLazyPropertyDeclaration", testLazyPropertyDeclaration),
+            ("testDynamicPropertyDeclaration", testDynamicPropertyDeclaration),
             ("testGenericPropertyDeclaration", testGenericPropertyDeclaration),
             ("testPropertyDeclarationWithWillSet", testPropertyDeclarationWithWillSet),
             ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -437,7 +437,7 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
             .token("0", .number),
             .whitespace("\n"),
             .plainText("}")
-            ])
+        ])
     }
 
 


### PR DESCRIPTION
This PR adds support (and related test) for the "dynamic" keyword, which was previously recognized as plain text, as shown in the image below (generated on splash.rambo.codes) :

![generate-3](https://user-images.githubusercontent.com/23129028/54121267-534dbf80-43fa-11e9-9528-2135740d1680.png)
