### PR TITLE
Add support for Swift 5 single-line raw strings

### DIFF
--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -100,6 +100,24 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testSingleLineRawStringLiteral() {
+        let components = highlighter.highlight("""
+        #"A raw string \\(withoutInterpolation) yes"#
+        """)
+
+        XCTAssertEqual(components, [
+            .token("#\"A", .string),
+            .whitespace(" "),
+            .token("raw", .string),
+            .whitespace(" "),
+            .token("string", .string),
+            .whitespace(" "),
+            .token("\\(withoutInterpolation)", .string),
+            .whitespace(" "),
+            .token("yes\"#", .string)
+        ])
+    }
+
     func testDoubleLiteral() {
         let components = highlighter.highlight("let double = 1.13")
 
@@ -142,6 +160,7 @@ extension LiteralTests {
             ("testStringLiteralWithAttribute", testStringLiteralWithAttribute),
             ("testStringLiteralInterpolation", testStringLiteralInterpolation),
             ("testMultiLineStringLiteral", testMultiLineStringLiteral),
+            ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
             ("testDoubleLiteral", testDoubleLiteral),
             ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators)
         ]


### PR DESCRIPTION
This change makes Splash capable of highlighting Swift 5 raw strings, although it’s currently limited to single line string literals. Support for multi-line literals will be added in a future commit.