### PR TITLE
Add support for multi-line Swift 5 raw strings

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -103,7 +103,13 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .string }
 
         func matches(_ segment: Segment) -> Bool {
-            return segment.isWithinStringLiteral(withStart: "#\"", end: "\"#")
+            if segment.isWithinStringLiteral(withStart: "#\"", end: "\"#") {
+                return true
+            }
+
+            let multiLineStartCount = segment.tokens.count(of: "#\"\"\"")
+            let multiLineEndCount = segment.tokens.count(of: "\"\"\"#")
+            return multiLineStartCount != multiLineEndCount
         }
     }
 

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -118,6 +118,41 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testMultiLineRawStringLiteral() {
+        let components = highlighter.highlight("""
+        #\"\"\"
+        A raw string \\(withoutInterpolation)
+        with multiple lines. #" Nested "#
+        \"\"\"#
+        """)
+
+        XCTAssertEqual(components, [
+            .token("#\"\"\"", .string),
+            .whitespace("\n"),
+            .token("A", .string),
+            .whitespace(" "),
+            .token("raw", .string),
+            .whitespace(" "),
+            .token("string", .string),
+            .whitespace(" "),
+            .token("\\(withoutInterpolation)", .string),
+            .whitespace("\n"),
+            .token("with", .string),
+            .whitespace(" "),
+            .token("multiple", .string),
+            .whitespace(" "),
+            .token("lines.", .string),
+            .whitespace(" "),
+            .token("#\"", .string),
+            .whitespace(" "),
+            .token("Nested", .string),
+            .whitespace(" "),
+            .token("\"#", .string),
+            .whitespace("\n"),
+            .token("\"\"\"#", .string)
+        ])
+    }
+
     func testDoubleLiteral() {
         let components = highlighter.highlight("let double = 1.13")
 
@@ -161,6 +196,7 @@ extension LiteralTests {
             ("testStringLiteralInterpolation", testStringLiteralInterpolation),
             ("testMultiLineStringLiteral", testMultiLineStringLiteral),
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
+            ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),
             ("testDoubleLiteral", testDoubleLiteral),
             ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators)
         ]


### PR DESCRIPTION
This change extends the support for Swift 5 raw strings to also cover multi-line literals.