### PR TITLE
README: Bump up the number of tools from three to four

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Welcome to **Splash** - a fast, lightweight and flexible Swift syntax highlighte
 
 ## Usage
 
-Splash can be used either as a library in your own Swift Package Manager-powered tool or script, or by using one of the three built-in command line tools that act as frontends for the Splash library.
+Splash can be used either as a library in your own Swift Package Manager-powered tool or script, or by using one of the four built-in command line tools that act as frontends for the Splash library.
 
 ### 🌍 On the web
 
@@ -28,10 +28,10 @@ Thanks to my good friend [Gui Rambo](https://twitter.com/_inside), you can [try 
 If you're using Jekyll, there's also a custom ```{% splash %}``` tag available for the Liquid templating language.
 
 👉 [splashtag](https://github.com/mannberg/splashtag)
-  
+
 ### 🖥 On the command line
 
-The easiest way to get started building things with Splash is to use one of the three built-in command line tools that each enable you to use Splash in different ways.
+The easiest way to get started building things with Splash is to use one of the four built-in command line tools that each enable you to use Splash in different ways.
 
 #### SplashHTMLGen
 
@@ -174,13 +174,13 @@ To run a tool without installing it, you can use the Swift Package Manager's `ru
 $ swift run SplashHTMLGen "func hello(world: String) -> Int"
 ```
 
-To install all three command line tools globally on your system, use Make:
+To install all four command line tools globally on your system, use Make:
 
 ```
 $ make install
 ```
 
-That will install the following three tools in your `/usr/local/bin` folder:
+That will install the following four tools in your `/usr/local/bin` folder:
 
 ```
 SplashHTMLGen


### PR DESCRIPTION
With the addition of SplashMarkdown, the tools now are four instead of three. With this PR I made the appropriate changes to the README to reflect that change. 