### PR TITLE
Correctly highlight generic parameters

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -326,6 +326,11 @@ private extension SwiftGrammar {
                         foundOpeningBracket = true
                     }
 
+                    // Handling generic lists for parameters, rather than declarations
+                    if foundOpeningBracket && token == ":" {
+                        return true
+                    }
+
                     guard !declarationKeywords.contains(token) else {
                         // If it turns out that we weren't in fact inside of a generic
                         // declaration, (lacking "<"), then highlight the type as normal.

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -150,6 +150,33 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testGenericFunctionDeclarationWithGenericParameter() {
+        let components = highlighter.highlight("func value<T>(at keyPath: KeyPath<Element, T>) -> T? {}")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("value<T>(at"),
+            .whitespace(" "),
+            .plainText("keyPath:"),
+            .whitespace(" "),
+            .token("KeyPath", .type),
+            .plainText("<"),
+            .token("Element", .type),
+            .plainText(","),
+            .whitespace(" "),
+            .token("T", .type),
+            .plainText(">)"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("T", .type),
+            .plainText("?"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testGenericStructDeclaration() {
         let components = highlighter.highlight("struct MyStruct<A: Hello, B> {}")
 
@@ -833,6 +860,7 @@ extension DeclarationTests {
             ("testGenericFunctionDeclarationWithoutConstraints", testGenericFunctionDeclarationWithoutConstraints),
             ("testGenericFunctionDeclarationWithSingleConstraint", testGenericFunctionDeclarationWithSingleConstraint),
             ("testGenericFunctionDeclarationWithMultipleConstraints", testGenericFunctionDeclarationWithMultipleConstraints),
+            ("testGenericFunctionDeclarationWithGenericParameter", testGenericFunctionDeclarationWithGenericParameter),
             ("testGenericStructDeclaration", testGenericStructDeclaration),
             ("testClassDeclaration", testClassDeclaration),
             ("testCompactClassDeclarationWithInitializer", testCompactClassDeclarationWithInitializer),


### PR DESCRIPTION
This patch makes Splash highlight generics that appear as part of a generic function’s parameter list in a correct way.