### PR TITLE
Correctly highlight the root level of a key path

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -29,6 +29,7 @@ public struct SwiftGrammar: Grammar {
             NumberRule(),
             TypeRule(),
             CallRule(),
+            KeyPathRule(),
             PropertyRule(),
             DotAccessRule(),
             KeywordRule()
@@ -363,6 +364,14 @@ private extension SwiftGrammar {
             }
 
             return segment.tokens.onSameLine.first != "import"
+        }
+    }
+
+    struct KeyPathRule: SyntaxRule {
+        var tokenType: TokenType { return .property }
+
+        func matches(_ segment: Segment) -> Bool {
+            return segment.tokens.previous == "\\."
         }
     }
 

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -205,6 +205,24 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testKeyPathLiteral() {
+        let components = highlighter.highlight("let value = object[keyPath: \\.property]")
+
+        XCTAssertEqual(components, [
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("value"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .plainText("object[keyPath:"),
+            .whitespace(" "),
+            .plainText("\\."),
+            .token("property", .property),
+            .plainText("]")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -223,7 +241,8 @@ extension LiteralTests {
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
             ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),
             ("testDoubleLiteral", testDoubleLiteral),
-            ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators)
+            ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators),
+            ("testKeyPathLiteral", testKeyPathLiteral)
         ]
     }
 }


### PR DESCRIPTION
When key path literals are used, Splash will now correctly highlight the root level of that key path as a property, rather than as plain text.