### PR TITLE
Fix highlighting for nested escaping closures

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -17,6 +17,7 @@ public struct SwiftGrammar: Grammar {
         delimiters.remove("_")
         delimiters.remove("\"")
         delimiters.remove("#")
+        delimiters.remove("@")
         self.delimiters = delimiters
 
         syntaxRules = [
@@ -96,7 +97,7 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .keyword }
 
         func matches(_ segment: Segment) -> Bool {
-            return segment.tokens.current == "@" || segment.tokens.previous == "@"
+            return segment.tokens.current.hasPrefix("@")
         }
     }
 

--- a/Tests/SplashTests/Tests/ClosureTests.swift
+++ b/Tests/SplashTests/Tests/ClosureTests.swift
@@ -124,6 +124,33 @@ final class ClosureTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testNestedEscapingClosure() {
+        let components = highlighter.highlight("let closures = [(@escaping () -> Void) -> Void]()")
+
+        XCTAssertEqual(components, [
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("closures"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .plainText("[("),
+            .token("@escaping", .keyword),
+            .whitespace(" "),
+            .plainText("()"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Void", .type),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Void", .type),
+            .plainText("]()")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -138,7 +165,8 @@ extension ClosureTests {
             ("testClosureArgumentWithSingleArgument", testClosureArgumentWithSingleArgument),
             ("testClosureArgumentWithMultipleArguments", testClosureArgumentWithMultipleArguments),
             ("testEscapingClosureArgument", testEscapingClosureArgument),
-            ("testPassingClosureAsArgument", testPassingClosureAsArgument)
+            ("testPassingClosureAsArgument", testPassingClosureAsArgument),
+            ("testNestedEscapingClosure", testNestedEscapingClosure)
         ]
     }
 }


### PR DESCRIPTION
This patch makes Splash correctly highlight nested closures marked with the `@escaping` attribute. The fix is to start treating `@` like a proper token, rather than as a delimiter.