### PR TITLE
Correctly highlight key paths passed as arguments

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -231,7 +231,7 @@ private extension SwiftGrammar {
                 }
             }
 
-            return segment.tokens.next.isAny(of: "(", "()", "())", "(.", "({", "().")
+            return segment.tokens.next.isAny(of: "(", "()", "())", "(.", "({", "().", #"(\."#)
         }
     }
 
@@ -377,7 +377,7 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .property }
 
         func matches(_ segment: Segment) -> Bool {
-            return segment.tokens.previous == "\\."
+            return segment.tokens.previous.isAny(of: #"\."#, #"(\."#)
         }
     }
 

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -223,6 +223,24 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testKeyPathLiteralsAsArguments() {
+        let components = highlighter.highlight(#"user.bind(\.name, to: \.text)"#)
+
+        XCTAssertEqual(components, [
+            .plainText("user."),
+            .token("bind", .call),
+            .plainText(#"(\."#),
+            .token("name", .property),
+            .plainText(","),
+            .whitespace(" "),
+            .plainText("to:"),
+            .whitespace(" "),
+            .plainText(#"\."#),
+            .token("text", .property),
+            .plainText(")")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -242,7 +260,8 @@ extension LiteralTests {
             ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),
             ("testDoubleLiteral", testDoubleLiteral),
             ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators),
-            ("testKeyPathLiteral", testKeyPathLiteral)
+            ("testKeyPathLiteral", testKeyPathLiteral),
+            ("testKeyPathLiteralsAsArguments", testKeyPathLiteralsAsArguments)
         ]
     }
 }


### PR DESCRIPTION
This makes Splash correctly highlight key paths that are passed as arguments to a function, especially when there’s no external parameter label for that argument.