### PR TITLE
Fix highlighting for keywords used as generic function parameter labels

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -271,7 +271,7 @@ private extension SwiftGrammar {
 
                 // Don't highlight most keywords when used as a parameter label
                 if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false") {
-                    guard !previousToken.isAny(of: "(", ",") else {
+                    guard !previousToken.isAny(of: "(", ",", ">(") else {
                         return false
                     }
                 }

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -88,6 +88,26 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testGenericFunctionDeclarationWithKeywordArgumentLabel() {
+        let components = highlighter.highlight("func perform<O: AnyObject>(for object: O) {}")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("perform<O:"),
+            .whitespace(" "),
+            .token("AnyObject", .type),
+            .plainText(">(for"),
+            .whitespace(" "),
+            .plainText("object:"),
+            .whitespace(" "),
+            .token("O", .type),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testGenericFunctionDeclarationWithoutConstraints() {
         let components = highlighter.highlight("func hello<A, B>(a: A, b: B)")
 
@@ -857,6 +877,7 @@ extension DeclarationTests {
             ("testPublicFunctionDeclarationWithDocumentationEndingWithDot", testPublicFunctionDeclarationWithDocumentationEndingWithDot),
             ("testFunctionDeclarationWithEmptyExternalLabel", testFunctionDeclarationWithEmptyExternalLabel),
             ("testFunctionDeclarationWithKeywordArgumentLabel", testFunctionDeclarationWithKeywordArgumentLabel),
+            ("testGenericFunctionDeclarationWithKeywordArgumentLabel", testGenericFunctionDeclarationWithKeywordArgumentLabel),
             ("testGenericFunctionDeclarationWithoutConstraints", testGenericFunctionDeclarationWithoutConstraints),
             ("testGenericFunctionDeclarationWithSingleConstraint", testGenericFunctionDeclarationWithSingleConstraint),
             ("testGenericFunctionDeclarationWithMultipleConstraints", testGenericFunctionDeclarationWithMultipleConstraints),


### PR DESCRIPTION
This patch fixes highlighting for parameter labels that also match a keyword, when used within a generic function declaration.