### PR TITLE
Makefile: Support Swift 5 toolchain for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
 	swift package update
-	swift build -c release -Xswiftc -static-stdlib
+	swift build -c release
 	install .build/Release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
 	install .build/Release/SplashMarkdown /usr/local/bin/SplashMarkdown
 	install .build/Release/SplashImageGen /usr/local/bin/SplashImageGen


### PR DESCRIPTION
This change removes static linking of the standard library when installing the command line tools bundled with Splash, making it possible to install them using the Swift 5 toolchain when using `make`.