### PR TITLE
Fix highlighting for inout closure arguments

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -272,7 +272,7 @@ private extension SwiftGrammar {
                 }
 
                 // Don't highlight most keywords when used as a parameter label
-                if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false") {
+                if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout") {
                     guard !previousToken.isAny(of: "(", ",", ">(") else {
                         return false
                     }

--- a/Tests/SplashTests/Tests/ClosureTests.swift
+++ b/Tests/SplashTests/Tests/ClosureTests.swift
@@ -110,6 +110,27 @@ final class ClosureTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testClosureWithInoutArgument() {
+        let components = highlighter.highlight("func add(closure: (inout Value) -> Void)")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("add(closure:"),
+            .whitespace(" "),
+            .plainText("("),
+            .token("inout", .keyword),
+            .whitespace(" "),
+            .token("Value", .type),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Void", .type),
+            .plainText(")")
+        ])
+    }
+
     func testPassingClosureAsArgument() {
         let components = highlighter.highlight("object.call({ $0 })")
 
@@ -194,6 +215,7 @@ extension ClosureTests {
             ("testClosureArgumentWithSingleArgument", testClosureArgumentWithSingleArgument),
             ("testClosureArgumentWithMultipleArguments", testClosureArgumentWithMultipleArguments),
             ("testEscapingClosureArgument", testEscapingClosureArgument),
+            ("testClosureWithInoutArgument", testClosureWithInoutArgument),
             ("testPassingClosureAsArgument", testPassingClosureAsArgument),
             ("testNestedEscapingClosure", testNestedEscapingClosure),
             ("testClosureArgumentShorthands", testClosureArgumentShorthands)


### PR DESCRIPTION
This patch makes Splash correctly highlight the `inout` keyword when it appears as part of a closure argument definition.