### PR TITLE
Enable Splash to be compiled for iOS as a Swift Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
 /Packages
+/.swiftpm
 /*.xcodeproj
 Package.resolved

--- a/Tests/SplashTests/Core/SplashTestCase.swift
+++ b/Tests/SplashTests/Core/SplashTestCase.swift
@@ -9,7 +9,7 @@ import XCTest
 
 /// Abstract base class for all Splash tests
 class SplashTestCase: XCTestCase {
-    #if !os(Linux)
+    #if os(macOS)
     func testHasLinuxVerificationTest() {
         let concreteType = type(of: self)
 

--- a/Tests/SplashTests/Core/XCTestManifests.swift
+++ b/Tests/SplashTests/Core/XCTestManifests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 
-#if !os(macOS)
+#if os(Linux)
 
 public func makeLinuxTests() -> [XCTestCaseEntry] {
     return [


### PR DESCRIPTION
While Splash has supported iOS since its early days, this change makes it possible to compile the iOS version as a Swift Package, using Xcode 11.

The changes require us to not make the assumption that != macOS == Linux.

(Also git ignore the new `.swiftpm` directory that SwiftPM now uses)