### PR TITLE
Add support for Swift 5.1’s opaque return types

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -52,7 +52,7 @@ private extension SwiftGrammar {
         "lazy", "subscript", "defer", "inout", "while",
         "continue", "fallthrough", "repeat", "indirect",
         "deinit", "is", "#file", "#line", "#function",
-        "dynamic"
+        "dynamic", "some"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -858,6 +858,31 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithOpaqueReturnType() {
+        let components = highlighter.highlight(#"func make() -> some View { Text("!") }"#)
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("make()"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("some", .keyword),
+            .whitespace(" "),
+            .token("View", .type),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("Text", .type),
+            .plainText("("),
+            .token(#""!""#, .string),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testIndirectEnumDeclaration() {
         let components = highlighter.highlight("""
         indirect enum Content {
@@ -934,6 +959,7 @@ extension DeclarationTests {
             ("testFunctionDeclarationWithPreProcessors", testFunctionDeclarationWithPreProcessors),
             ("testNonMutatingFunction", testNonMutatingFunction),
             ("testRethrowingFunctionDeclaration", testRethrowingFunctionDeclaration),
+            ("testFunctionDeclarationWithOpaqueReturnType", testFunctionDeclarationWithOpaqueReturnType),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration)
         ]
     }


### PR DESCRIPTION
This change adds support for the Swift 5.1 `some` keyword, which is used to declare opaque return types.