### PR TITLE
Fix highlighting for #available checks

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -52,7 +52,7 @@ private extension SwiftGrammar {
         "lazy", "subscript", "defer", "inout", "while",
         "continue", "fallthrough", "repeat", "indirect",
         "deinit", "is", "#file", "#line", "#function",
-        "dynamic", "some"
+        "dynamic", "some", "#available"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/PreprocessorTests.swift
+++ b/Tests/SplashTests/Tests/PreprocessorTests.swift
@@ -62,6 +62,24 @@ final class PreprocessorTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testAvailabilityCheck() {
+        let components = highlighter.highlight("if #available(iOS 13, *) {}")
+
+        XCTAssertEqual(components, [
+            .token("if", .keyword),
+            .whitespace(" "),
+            .token("#available", .keyword),
+            .plainText("(iOS"),
+            .whitespace(" "),
+            .token("13", .number),
+            .plainText(","),
+            .whitespace(" "),
+            .plainText("*)"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -72,7 +90,8 @@ extension PreprocessorTests {
         return [
             ("testPreprocessing", testPreprocessing),
             ("testSelector", testSelector),
-            ("testFunctionAttribute", testFunctionAttribute)
+            ("testFunctionAttribute", testFunctionAttribute),
+            ("testAvailabilityCheck", testAvailabilityCheck)
         ]
     }
 }


### PR DESCRIPTION
This patch makes availability checks using `#available` highlight correctly, by treating `#available` like a keyword.