### PR TITLE
Support types and functions named with a leading underscore

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -189,7 +189,11 @@ private extension SwiftGrammar {
         }
 
         func matches(_ segment: Segment) -> Bool {
-            guard segment.tokens.current.startsWithLetter else {
+            let token = segment.tokens.current.trimmingCharacters(
+                in: CharacterSet(charactersIn: "_")
+            )
+
+            guard token.startsWithLetter else {
                 return false
             }
 
@@ -304,7 +308,11 @@ private extension SwiftGrammar {
                 }
             }
 
-            guard segment.tokens.current.isCapitalized else {
+            let token = segment.tokens.current.trimmingCharacters(
+                in: CharacterSet(charactersIn: "_")
+            )
+
+            guard token.isCapitalized else {
                 return false
             }
 
@@ -315,7 +323,7 @@ private extension SwiftGrammar {
             // The XCTAssert family of functions is a bit of an edge case,
             // since they start with capital letters. Since they are so
             // commonly used, we'll add a special case for them here:
-            guard !segment.tokens.current.starts(with: "XCTAssert") else {
+            guard !token.starts(with: "XCTAssert") else {
                 return false
             }
 

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -330,6 +330,24 @@ final class StatementTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testInitializingTypeWithLeadingUnderscore() {
+        let components = highlighter.highlight("_MyType()")
+
+        XCTAssertEqual(components, [
+            .token("_MyType", .type),
+            .plainText("()")
+        ])
+    }
+
+    func testCallingFunctionWithLeadingUnderscore() {
+        let components = highlighter.highlight("_myFunction()")
+
+        XCTAssertEqual(components, [
+            .token("_myFunction", .call),
+            .plainText("()")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -348,7 +366,9 @@ extension StatementTests {
             ("testSwitchStatementWithOptional", testSwitchStatementWithOptional),
             ("testForStatementWithStaticProperty", testForStatementWithStaticProperty),
             ("testForStatementWithContinue", testForStatementWithContinue),
-            ("testRepeatWhileStatement", testRepeatWhileStatement)
+            ("testRepeatWhileStatement", testRepeatWhileStatement),
+            ("testInitializingTypeWithLeadingUnderscore", testInitializingTypeWithLeadingUnderscore),
+            ("testCallingFunctionWithLeadingUnderscore", testCallingFunctionWithLeadingUnderscore)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes syntax highlighting for types and functions which names begin with an underscore. Previously these entities would be treated as plain text, but now they’re highlighted correctly as either types or function calls.