### PR TITLE
Fix highlighting for interpolated closure shorthand arguments

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -18,6 +18,7 @@ public struct SwiftGrammar: Grammar {
         delimiters.remove("\"")
         delimiters.remove("#")
         delimiters.remove("@")
+        delimiters.remove("$")
         self.delimiters = delimiters
 
         syntaxRules = [

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -76,6 +76,16 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testStringLiteralWithInterpolatedClosureArgumentShorthand() {
+        let components = highlighter.highlight(#""\($0)""#)
+
+        XCTAssertEqual(components, [
+            .token("\"", .string),
+            .plainText(#"\($0)"#),
+            .token("\"", .string)
+        ])
+    }
+
     func testStringLiteralWithCustomIterpolation() {
         let components = highlighter.highlight("""
         "Hello \\(label: a, b) world \\(label: call())"
@@ -254,6 +264,7 @@ extension LiteralTests {
             ("testStringLiteralWithEscapedQuote", testStringLiteralWithEscapedQuote),
             ("testStringLiteralWithAttribute", testStringLiteralWithAttribute),
             ("testStringLiteralInterpolation", testStringLiteralInterpolation),
+            ("testStringLiteralWithInterpolatedClosureArgumentShorthand", testStringLiteralWithInterpolatedClosureArgumentShorthand),
             ("testStringLiteralWithCustomIterpolation", testStringLiteralWithCustomIterpolation),
             ("testMultiLineStringLiteral", testMultiLineStringLiteral),
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),


### PR DESCRIPTION
This patch fixes syntax highlighting for when shorthand closure arguments ($0, $1…) are interpolated into a string literal. The fix is to no longer treat “$” as a delimiter, which should help solve similar issues that might be encountered in the future as well.