### PR TITLE
MarkdownDecorator: Don’t hard code line breaks

### DIFF
--- a/Sources/Splash/Output/MarkdownDecorator.swift
+++ b/Sources/Splash/Output/MarkdownDecorator.swift
@@ -38,9 +38,7 @@ public struct MarkdownDecorator {
             }
 
             output.append("""
-            <pre class="splash"><code>
-            \(code)
-            </code></pre>
+            <pre class="splash"><code>\(code)</code></pre>
             """)
         }
 

--- a/Tests/SplashTests/Tests/MarkdownTests.swift
+++ b/Tests/SplashTests/Tests/MarkdownTests.swift
@@ -33,9 +33,7 @@ final class MarkdownTests: SplashTestCase {
 
         Text text text `inline.code.shouldNotBeHighlighted()`.
 
-        <pre class="splash"><code>
-        <span class="keyword">struct</span> Hello: <span class="type">Protocol</span> {}
-        </code></pre>
+        <pre class="splash"><code><span class="keyword">struct</span> Hello: <span class="type">Protocol</span> {}</code></pre>
 
         Text.
         """
@@ -57,9 +55,7 @@ final class MarkdownTests: SplashTestCase {
         let expectedResult = """
         Text text.
 
-        <pre class="splash"><code>
-        struct Hello: Protocol {}
-        </code></pre>
+        <pre class="splash"><code>struct Hello: Protocol {}</code></pre>
 
         Text.
         """


### PR DESCRIPTION
This patch makes MarkdownDecorator not include line breaks before and after the `<pre>` and `<code>` tags that it adds to code blocks, since this will be rendered as whitespace in the browser.