### PR TITLE
Tweaks to how dot syntax is highlighted

### DIFF
--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -452,7 +452,7 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
             .whitespace(" "),
             .token("self", .keyword),
             .plainText("."),
-            .token("init", .call),
+            .token("init", .keyword),
             .plainText("()"),
             .whitespace(" "),
             .plainText("}"),

--- a/Tests/SplashTests/Tests/EnumTests.swift
+++ b/Tests/SplashTests/Tests/EnumTests.swift
@@ -37,13 +37,13 @@ final class EnumTests: SyntaxHighlighterTestCase {
         ])
     }
 
-    func testEnumDotSyntaxWithAssociatedValue() {
+    func testEnumDotSyntaxWithAssociatedValueTreatedAsCall() {
         let components = highlighter.highlight("call(.error(error))")
 
         XCTAssertEqual(components, [
             .token("call", .call),
             .plainText("(."),
-            .token("error", .dotAccess),
+            .token("error", .call),
             .plainText("(error))")
         ])
     }
@@ -68,7 +68,7 @@ extension EnumTests {
         return [
             ("testEnumDotSyntaxInAssignment", testEnumDotSyntaxInAssignment),
             ("testEnumDotSyntaxAsArgument", testEnumDotSyntaxAsArgument),
-            ("testEnumDotSyntaxWithAssociatedValue", testEnumDotSyntaxWithAssociatedValue),
+            ("testEnumDotSyntaxWithAssociatedValueTreatedAsCall", testEnumDotSyntaxWithAssociatedValueTreatedAsCall),
             ("testUsingEnumInSubscript", testUsingEnumInSubscript)
         ]
     }

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -50,7 +50,7 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
             .whitespace(" "),
             .token("String", .type),
             .plainText("."),
-            .token("init", .call),
+            .token("init", .keyword),
             .plainText("()")
         ])
     }

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -106,7 +106,7 @@ final class StatementTests: SyntaxHighlighterTestCase {
         ])
     }
 
-    func testSwitchStatementWithAssociatedValues() {
+    func testSwitchStatementWithSingleAssociatedValue() {
         let components = highlighter.highlight("""
         switch value {
         case .one(let a): break
@@ -128,6 +128,42 @@ final class StatementTests: SyntaxHighlighterTestCase {
             .token("let", .keyword),
             .whitespace(" "),
             .plainText("a):"),
+            .whitespace(" "),
+            .token("break", .keyword),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
+    func testSwitchStatementWithMultipleAssociatedValues() {
+        let components = highlighter.highlight("""
+        switch value {
+        case .one(let a), .two(let b): break
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("switch", .keyword),
+            .whitespace(" "),
+            .plainText("value"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n"),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .plainText("."),
+            .token("one", .dotAccess),
+            .plainText("("),
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("a),"),
+            .whitespace(" "),
+            .plainText("."),
+            .token("two", .dotAccess),
+            .plainText("("),
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("b):"),
             .whitespace(" "),
             .token("break", .keyword),
             .whitespace("\n"),
@@ -360,7 +396,8 @@ extension StatementTests {
             ("testImportStatementWithSubmodule", testImportStatementWithSubmodule),
             ("testChainedIfElseStatements", testChainedIfElseStatements),
             ("testSwitchStatement", testSwitchStatement),
-            ("testSwitchStatementWithAssociatedValues", testSwitchStatementWithAssociatedValues),
+            ("testSwitchStatementWithSingleAssociatedValue", testSwitchStatementWithSingleAssociatedValue),
+            ("testSwitchStatementWithMultipleAssociatedValues", testSwitchStatementWithMultipleAssociatedValues),
             ("testSwitchStatementWithFallthrough", testSwitchStatementWithFallthrough),
             ("testSwitchStatementWithTypePatternMatching", testSwitchStatementWithTypePatternMatching),
             ("testSwitchStatementWithOptional", testSwitchStatementWithOptional),


### PR DESCRIPTION
- Don’t highlight what *could* be a static method call using the `dotAccess` style, only highlight tokens that are either value-less enum cases or static properties.
- The exception to the above rule is within `switch` statements, in which even call-like tokens are assumed to be enum cases.
- Highlight calls to `.init()` as keywords, for consistency with other `init` usages.