### PR TITLE
Add a test for indented function calls

### DIFF
--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -130,6 +130,26 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testIndentedFunctionCalls() {
+        let components = highlighter.highlight("""
+        variable
+            .callOne()
+            .callTwo()
+        """)
+
+        XCTAssertEqual(components, [
+            .plainText("variable"),
+            .whitespace("\n    "),
+            .plainText("."),
+            .token("callOne", .call),
+            .plainText("()"),
+            .whitespace("\n    "),
+            .plainText("."),
+            .token("callTwo", .call),
+            .plainText("()")
+        ])
+    }
+
     func testXCTAssertCalls() {
         let components = highlighter.highlight("XCTAssertTrue(variable)")
 
@@ -156,6 +176,7 @@ extension FunctionCallTests {
             ("testCallingStaticMethodOnGenericType", testCallingStaticMethodOnGenericType),
             ("testPassingTypeToFunction", testPassingTypeToFunction),
             ("testPassingBoolToUnnamedArgument", testPassingBoolToUnnamedArgument),
+            ("testIndentedFunctionCalls", testIndentedFunctionCalls),
             ("testXCTAssertCalls", testXCTAssertCalls)
         ]
     }


### PR DESCRIPTION
This change adds a test that verifies that indented function calls are correctly highlighted. This was fixed as part of the previous change to make static methods highlight correctly, but this test will ensure we don’t see any regressions for this particular use case.