### PR TITLE
Fix highlighting when delimiters appear next to string interpolation

### DIFF
--- a/Sources/Splash/Grammar/Grammar.swift
+++ b/Sources/Splash/Grammar/Grammar.swift
@@ -11,11 +11,29 @@ import Foundation
 /// of the Swift language grammar.
 public protocol Grammar {
     /// The set of characters that make up the delimiters that separates
-    /// tokens within the language, such as punctuation characters.
+    /// tokens within the language, such as punctuation characters. You
+    /// can control whether delimiters should be merged when forming
+    /// tokens by implementing the `isDelimiter(mergableWith:)` method.
     var delimiters: CharacterSet { get }
     /// The rules that define the syntax of the language. When tokenizing,
     /// the rules will be iterated over in sequence, and the first rule
     /// that matches a given code segment will be used to determine that
     /// segment's token type.
     var syntaxRules: [SyntaxRule] { get }
+
+    /// Return whether two delimiters should be merged into a single
+    /// token, or whether they should be treated as separate ones.
+    /// The delimiters are passed in the order in which they appear
+    /// in the source code to be highlighted.
+    /// - Parameter delimiterA: The first delimiter
+    /// - Parameter delimiterB: The second delimiter
+    func isDelimiter(_ delimiterA: Character,
+                     mergableWith delimiterB: Character) -> Bool
+}
+
+public extension Grammar {
+    func isDelimiter(_ delimiterA: Character,
+                     mergableWith delimiterB: Character) -> Bool {
+        return true
+    }
 }

--- a/Sources/Splash/Syntax/SyntaxHighlighter.swift
+++ b/Sources/Splash/Syntax/SyntaxHighlighter.swift
@@ -41,7 +41,7 @@ public struct SyntaxHighlighter<Format: OutputFormat> {
             state = nil
         }
 
-        for segment in tokenizer.segmentsByTokenizing(code, delimiters: grammar.delimiters) {
+        for segment in tokenizer.segmentsByTokenizing(code, using: grammar) {
             let token = segment.tokens.current
             let whitespace = segment.trailingWhitespace
 

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -110,6 +110,26 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testStringLiteralWithInterpolationSurroundedByBrackets() {
+        let components = highlighter.highlight(#""[\(text)]""#)
+
+        XCTAssertEqual(components, [
+            .token(#""["#, .string),
+            .plainText(#"\(text)"#),
+            .token(#"]""#, .string)
+        ])
+    }
+
+    func testStringLiteralWithInterpolationPrefixedByPunctuation() {
+        let components = highlighter.highlight(#"".\(text)""#)
+
+        XCTAssertEqual(components, [
+            .token("\".", .string),
+            .plainText(#"\(text)"#),
+            .token("\"", .string)
+        ])
+    }
+
     func testMultiLineStringLiteral() {
         let components = highlighter.highlight("""
         let string = \"\"\"
@@ -266,6 +286,8 @@ extension LiteralTests {
             ("testStringLiteralInterpolation", testStringLiteralInterpolation),
             ("testStringLiteralWithInterpolatedClosureArgumentShorthand", testStringLiteralWithInterpolatedClosureArgumentShorthand),
             ("testStringLiteralWithCustomIterpolation", testStringLiteralWithCustomIterpolation),
+            ("testStringLiteralWithInterpolationSurroundedByBrackets", testStringLiteralWithInterpolationSurroundedByBrackets),
+            ("testStringLiteralWithInterpolationPrefixedByPunctuation", testStringLiteralWithInterpolationPrefixedByPunctuation),
             ("testMultiLineStringLiteral", testMultiLineStringLiteral),
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
             ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),


### PR DESCRIPTION
This patch makes Splash correctly highlight strings in which a value is interpolated next to a delimiter character. The fix is to enable each `Grammar` implementation to decide whether two tokens should be *merged*, which in turn enables `SwiftGrammar` to veto that string interpolation delimiters should be merged with their predecessor.