### PR TITLE
Fix highlighting for comments ending with punctuation

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -283,7 +283,8 @@ private extension SwiftGrammar {
                 }
             }
 
-            if let previousToken = segment.tokens.previous {
+            if !segment.tokens.onSameLine.isEmpty,
+               let previousToken = segment.tokens.previous {
                 // Highlight the '(set)' part of setter access modifiers
                 switch segment.tokens.current {
                 case "(":

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -112,6 +112,25 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCommentEndingWithComma() {
+        let components = highlighter.highlight("""
+        // Hello,
+        class World {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("//", .comment),
+            .whitespace(" "),
+            .token("Hello,", .comment),
+            .whitespace("\n"),
+            .token("class", .keyword),
+            .whitespace(" "),
+            .plainText("World"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -123,7 +142,8 @@ extension CommentTests {
             ("testSingleLineComment", testSingleLineComment),
             ("testMultiLineComment", testMultiLineComment),
             ("testMultiLineCommentWithDoubleAsterisks", testMultiLineCommentWithDoubleAsterisks),
-            ("testMutliLineDocumentationComment", testMutliLineDocumentationComment)
+            ("testMutliLineDocumentationComment", testMutliLineDocumentationComment),
+            ("testCommentEndingWithComma", testCommentEndingWithComma)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes highlighting of any type declarations that follow a comment which was ended with a punctuation character. The fix is to only look at previous tokens on the same line when determining whether a given token is a keyword.