### PR TITLE
Fix highlighting for comments starting with a delimiter

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,6 +47,10 @@ public struct SwiftGrammar: Grammar {
             return false
         case (")", _):
             return false
+        case ("/", "/"), ("/", "*"):
+            return true
+        case ("/", _):
+            return false
         default:
             return true
         }

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -112,6 +112,11 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCommentStartingWithPunctuation() {
+        let components = highlighter.highlight("//.call()")
+        XCTAssertEqual(components, [.token("//.call()", .comment)])
+    }
+
     func testCommentEndingWithComma() {
         let components = highlighter.highlight("""
         // Hello,
@@ -143,6 +148,7 @@ extension CommentTests {
             ("testMultiLineComment", testMultiLineComment),
             ("testMultiLineCommentWithDoubleAsterisks", testMultiLineCommentWithDoubleAsterisks),
             ("testMutliLineDocumentationComment", testMutliLineDocumentationComment),
+            ("testCommentStartingWithPunctuation", testCommentStartingWithPunctuation),
             ("testCommentEndingWithComma", testCommentEndingWithComma)
         ]
     }


### PR DESCRIPTION
This patch fixes syntax highlighting for any comments that begin with a delimiter, which would previously prevent the comment’s leading token from being parsed correctly. The fix is to prevent slashes to be merged with any other delimiter, except for other slashes and asterisks.