### PR TITLE
Quick fix for single-expression raw string interpolation

### DIFF
--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -207,6 +207,18 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testRawStringWithInterpolation() {
+        let components = highlighter.highlight("#\"Hello \\#(variable) world\"#")
+
+        XCTAssertEqual(components, [
+            .token("#\"Hello", .string),
+            .whitespace(" "),
+            .plainText("\\#(variable)"),
+            .whitespace(" "),
+            .token("world\"#", .string)
+        ])
+    }
+
     func testDoubleLiteral() {
         let components = highlighter.highlight("let double = 1.13")
 
@@ -291,6 +303,7 @@ extension LiteralTests {
             ("testMultiLineStringLiteral", testMultiLineStringLiteral),
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
             ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),
+            ("testRawStringWithInterpolation", testRawStringWithInterpolation),
             ("testDoubleLiteral", testDoubleLiteral),
             ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators),
             ("testKeyPathLiteral", testKeyPathLiteral),


### PR DESCRIPTION
Raw string interpolation has proven to be a bit trickier to implement, since we don’t want to treat `#` as a delimiter (since it’s used in so many other ways in Swift, for example for `#if`, `#available`, etc.).

This patch contains a “quick fix” for supporting interpolated raw strings that contain a single expression per interpolation. A proper fix should be developed as soon as possible, but this unblocks using Splash to highlight most raw string interpolated code samples, for now.