### PR TITLE
Fix highlighting for strings within interpolation

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -154,12 +154,17 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .string }
 
         func matches(_ segment: Segment) -> Bool {
+            if segment.tokens.current.hasPrefix("\"") &&
+               segment.tokens.current.hasSuffix("\"") {
+                return true
+            }
+
             guard segment.isWithinStringLiteral(withStart: "\"", end: "\"") else {
                 return false
             }
 
             return !segment.isWithinStringInterpolation &&
-                !segment.isWithinRawStringInterpolation
+                   !segment.isWithinRawStringInterpolation
         }
     }
 

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -130,6 +130,21 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testStringLiteralWithInterpolationContainingString() {
+        let components = highlighter.highlight(#""\(name ?? "name")""#)
+
+        XCTAssertEqual(components, [
+            .token("\"", .string),
+            .plainText("\\(name"),
+            .whitespace(" "),
+            .plainText("??"),
+            .whitespace(" "),
+            .token("\"name\"", .string),
+            .plainText(")"),
+            .token("\"", .string)
+        ])
+    }
+
     func testMultiLineStringLiteral() {
         let components = highlighter.highlight("""
         let string = \"\"\"
@@ -300,6 +315,7 @@ extension LiteralTests {
             ("testStringLiteralWithCustomIterpolation", testStringLiteralWithCustomIterpolation),
             ("testStringLiteralWithInterpolationSurroundedByBrackets", testStringLiteralWithInterpolationSurroundedByBrackets),
             ("testStringLiteralWithInterpolationPrefixedByPunctuation", testStringLiteralWithInterpolationPrefixedByPunctuation),
+            ("testStringLiteralWithInterpolationContainingString", testStringLiteralWithInterpolationContainingString),
             ("testMultiLineStringLiteral", testMultiLineStringLiteral),
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
             ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),


### PR DESCRIPTION
This patch fixes syntax highlighting for string literals that appear within string interpolation. This patch only takes single words into account.