### PR TITLE
Correctly highlight generic subscript type lists

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -335,7 +335,7 @@ private extension SwiftGrammar {
         private let declarationKeywords: Set<String> = [
             "class", "struct", "enum", "func",
             "protocol", "typealias", "import",
-            "associatedtype"
+            "associatedtype", "subscript"
         ]
 
         func matches(_ segment: Segment) -> Bool {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -706,6 +706,45 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testGenericSubscriptDeclaration() {
+        let components = highlighter.highlight("""
+        extension Collection {
+            subscript<T>(key: Key<T>) -> T? { return nil }
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("extension", .keyword),
+            .whitespace(" "),
+            .token("Collection", .type),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("subscript", .keyword),
+            .plainText("<T>(key:"),
+            .whitespace(" "),
+            .token("Key", .type),
+            .plainText("<"),
+            .token("T", .type),
+            .plainText(">)"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("T", .type),
+            .plainText("?"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("return", .keyword),
+            .whitespace(" "),
+            .token("nil", .keyword),
+            .whitespace(" "),
+            .plainText("}"),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testDeferDeclaration() {
         let components = highlighter.highlight("func hello() { defer {} }")
 
@@ -1016,6 +1055,7 @@ extension DeclarationTests {
             ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),
             ("testPropertyWithSetterAccessLevel", testPropertyWithSetterAccessLevel),
             ("testSubscriptDeclaration", testSubscriptDeclaration),
+            ("testGenericSubscriptDeclaration", testGenericSubscriptDeclaration),
             ("testDeferDeclaration", testDeferDeclaration),
             ("testFunctionDeclarationWithInOutParameter", testFunctionDeclarationWithInOutParameter),
             ("testFunctionDeclarationWithNonEscapedKeywordAsName", testFunctionDeclarationWithNonEscapedKeywordAsName),


### PR DESCRIPTION
This patch fixes highlighting for types that appear within a list of a subscript’s generic types.