### PR TITLE
Correctly highlight `nil` when passed as a function argument

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -314,7 +314,7 @@ private extension SwiftGrammar {
                 }
 
                 // Don't highlight most keywords when used as a parameter label
-                if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout") {
+                if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout", "nil") {
                     guard !previousToken.isAny(of: "(", ",", ">(") else {
                         return false
                     }

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -23,6 +23,17 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionCallWithNil() {
+        let components = highlighter.highlight("handler(nil)")
+
+        XCTAssertEqual(components, [
+            .token("handler", .call),
+            .plainText("("),
+            .token("nil", .keyword),
+            .plainText(")")
+        ])
+    }
+
     func testImplicitInitializerCall() {
         let components = highlighter.highlight("let string = String()")
 
@@ -168,6 +179,7 @@ extension FunctionCallTests {
     static var allTests: [(String, TestClosure<FunctionCallTests>)] {
         return [
             ("testFunctionCallWithIntegers", testFunctionCallWithIntegers),
+            ("testFunctionCallWithNil", testFunctionCallWithNil),
             ("testImplicitInitializerCall", testImplicitInitializerCall),
             ("testExplicitInitializerCall", testExplicitInitializerCall),
             ("testDotSyntaxInitializerCall", testDotSyntaxInitializerCall),


### PR DESCRIPTION
This patch fixes syntax highlighting when `nil` is passed to a function that doesn’t have any parameter labels, such as `handler(nil)`.