### PR TITLE
Added Comment component test with a number

### DIFF
--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -138,7 +138,12 @@ final class CommentTests: SyntaxHighlighterTestCase {
         
     func testCommentWithNumber() {
         let components = highlighter.highlight("// 1")
-        XCTAssertEqual(components, [.token("// 1", .comment)])
+
+        XCTAssertEqual(components, [
+            .token("//", .comment),
+            .whitespace(" "),
+            .token("1", .comment)
+        ])
     }
 
     func testAllTestsRunOnLinux() {

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -135,6 +135,11 @@ final class CommentTests: SyntaxHighlighterTestCase {
             .plainText("{}")
         ])
     }
+        
+    func testCommentWithNumber() {
+        let components = highlighter.highlight("// 1")
+        XCTAssertEqual(components, [.token("// 1", .comment)])
+    }
 
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
@@ -149,7 +154,8 @@ extension CommentTests {
             ("testMultiLineCommentWithDoubleAsterisks", testMultiLineCommentWithDoubleAsterisks),
             ("testMutliLineDocumentationComment", testMutliLineDocumentationComment),
             ("testCommentStartingWithPunctuation", testCommentStartingWithPunctuation),
-            ("testCommentEndingWithComma", testCommentEndingWithComma)
+            ("testCommentEndingWithComma", testCommentEndingWithComma),
+            ("testCommentWithNumber", testCommentWithNumber),
         ]
     }
 }


### PR DESCRIPTION
```swift
// 1
```

Having a comment with a just a whitespace and a digit in a first line fails to highlight correctly. It treats `//` as normal text and `digit` as a number component.

Will work on a fix when I have time unless someone wants to take care of it.