### PR TITLE
Add support for the “prefix” keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -287,6 +287,10 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .keyword }
 
         func matches(_ segment: Segment) -> Bool {
+            if segment.tokens.current == "prefix" && segment.tokens.next == "func" {
+                return true
+            }
+
             if segment.tokens.next == ":" {
                 // Nil pattern matching inside of a switch statement case
                 if segment.tokens.current == "nil" {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -955,6 +955,31 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testPrefixFunctionDeclaration() {
+        let components = highlighter.highlight("prefix func !(rhs: Bool) -> Bool { !rhs }")
+
+        XCTAssertEqual(components, [
+            .token("prefix", .keyword),
+            .whitespace(" "),
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("!(rhs:"),
+            .whitespace(" "),
+            .token("Bool", .type),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("->"),
+            .whitespace(" "),
+            .token("Bool", .type),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .plainText("!rhs"),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testIndirectEnumDeclaration() {
         let components = highlighter.highlight("""
         indirect enum Content {
@@ -1064,6 +1089,7 @@ extension DeclarationTests {
             ("testNonMutatingFunction", testNonMutatingFunction),
             ("testRethrowingFunctionDeclaration", testRethrowingFunctionDeclaration),
             ("testFunctionDeclarationWithOpaqueReturnType", testFunctionDeclarationWithOpaqueReturnType),
+            ("testPrefixFunctionDeclaration", testPrefixFunctionDeclaration),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration),
             ("testWrappedPropertyDeclarations", testWrappedPropertyDeclarations)
         ]


### PR DESCRIPTION
This patch makes Splash correctly highlight the `prefix` keyword, which can only appear before `func`, so a special case was added for it (for now).