### PR TITLE
Added SwiftUITextOutputFormat to output a Text struct

### DIFF
--- a/Sources/Splash/Output/SwiftUITextOutputFormat.swift
+++ b/Sources/Splash/Output/SwiftUITextOutputFormat.swift
@@ -1,0 +1,79 @@
+//
+//  SwiftUITextOutputFormat.swift
+//
+//  Created by Andrew Eades on 02/01/2020.
+//  Copyright © 2020 Andrew Eades. All rights reserved.
+//
+
+import Splash
+import SwiftUI
+
+#if !os(Linux)
+
+import Foundation
+
+/// Output format to use to generate an NSAttributedString from the
+/// highlighted code. A `Theme` is used to determine what fonts and
+/// colors to use for the various tokens.
+public struct SwiftUITextOutputFormat: OutputFormat {
+    public var theme: Theme
+    
+    public init(theme: Theme) {
+        self.theme = theme
+    }
+    
+    public func makeBuilder() -> Builder {
+        return Builder(theme: theme)
+    }
+}
+
+public extension SwiftUITextOutputFormat {
+    struct Builder: OutputBuilder {
+        private let theme: Theme
+        private var texts = [Text]()
+        
+        fileprivate init(theme: Theme) {
+            self.theme = theme
+        }
+        
+        public mutating func addToken(_ token: String, ofType type: TokenType) {
+            let tokenColor = swiftUIColor(forType: type)
+                                        
+            texts.append(Text(token).foregroundColor(tokenColor))
+        }
+        
+        public mutating func addPlainText(_ plainText: String) {
+            let tokenColor = SwiftUI.Color(theme.plainTextColor)
+
+            texts.append(Text(plainText).foregroundColor(tokenColor))
+        }
+        
+        public mutating func addWhitespace(_ whitespace: String) {
+            let tokenColor = SwiftUI.Color.white
+            
+            texts.append(Text(whitespace).foregroundColor(tokenColor))
+        }
+        
+        public func build() -> Text {
+ 
+            let highlightedText = texts.reduce(Text(""), +)
+            
+            return highlightedText
+        }
+        
+        private func swiftUIColor(forType type: TokenType) -> SwiftUI.Color {
+            var tokenColor: SwiftUI.Color
+            
+            if let color = theme.tokenColors[type] {
+                tokenColor = SwiftUI.Color(color)
+            } else {
+                tokenColor = SwiftUI.Color.white
+            }
+            
+            return tokenColor
+        }
+        
+    }
+}
+
+#endif


### PR DESCRIPTION
This OutputFormat outputs a Text struct that can be used in a SwiftUI view. 
It ignores the font as you normally would apply the font with a `.font` modifier in SwiftUI.
Either we should convert the theme's font to a SwiftUI.Font and and use that or leave it to the user to style fonts separately from highlighting syntax colours. I favour the later as it fits better with the model of SwiftUI and leaves SwiftUITextOutputFormat to be only concerned with constructing the highlighted text but this might be confusing as it ignores the theme's font. However, the attributed text string is different to the font and they could be considered separate and treated separately as SwiftUi pushes us in that direction and an additional `.font` modifier would override any theme font anyway. Maybe this should really be a view modifier?