### PR TITLE
Fix comments with punctuation just prior or after

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -47,8 +47,12 @@ public struct SwiftGrammar: Grammar {
             return false
         case (")", _):
             return false
-        case ("/", "/"), ("/", "*"):
+        case ("/", "/"), ("/", "*"), ("*", "/"):
             return true
+        case ("(", "/"), ("/", ")"):
+            return false
+        case (_, "/"), ("/", _):
+            return false
         case ("/", _):
             return false
         default:

--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -49,11 +49,11 @@ public struct SwiftGrammar: Grammar {
             return false
         case ("/", "/"), ("/", "*"), ("*", "/"):
             return true
-        case ("(", "/"), ("/", ")"):
-            return false
-        case (_, "/"), ("/", _):
-            return false
         case ("/", _):
+            return false
+        case ("(", _) where delimiterB != ".":
+            return false
+        case (".", "/"):
             return false
         default:
             return true
@@ -104,6 +104,12 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .comment }
 
         func matches(_ segment: Segment) -> Bool {
+            if segment.tokens.current.hasPrefix("/*") {
+                if segment.tokens.current.hasSuffix("*/") {
+                    return true
+                }
+            }
+            
             if segment.tokens.current.hasPrefix("//") {
                 return true
             }

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -143,7 +143,7 @@ final class CommentTests: SyntaxHighlighterTestCase {
         (/**/)
         """)
 
-        XCTAssertEqual(components, [
+         XCTAssertEqual(components, [
             .plainText("("),
             .token("/*", .comment),
             .whitespace(" "),
@@ -158,8 +158,7 @@ final class CommentTests: SyntaxHighlighterTestCase {
             .token("World", .comment),
             .whitespace("\n"),
             .plainText("("),
-            .token("/*", .comment),
-            .token("*/", .comment),
+            .token("/**/", .comment),
             .plainText(")"),
         ])
     }

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -136,6 +136,34 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCommentWithNoWhiteSpaceToPunctuation() {
+        let components = highlighter.highlight("""
+        (/* Hello */)
+        .// World
+        (/**/)
+        """)
+
+        XCTAssertEqual(components, [
+            .plainText("("),
+            .token("/*", .comment),
+            .whitespace(" "),
+            .token("Hello", .comment),
+            .whitespace(" "),
+            .token("*/", .comment),
+            .plainText(")"),
+            .whitespace("\n"),
+            .plainText("."),
+            .token("//", .comment),
+            .whitespace(" "),
+            .token("World", .comment),
+            .whitespace("\n"),
+            .plainText("("),
+            .token("/*", .comment),
+            .token("*/", .comment),
+            .plainText(")"),
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -149,7 +177,8 @@ extension CommentTests {
             ("testMultiLineCommentWithDoubleAsterisks", testMultiLineCommentWithDoubleAsterisks),
             ("testMutliLineDocumentationComment", testMutliLineDocumentationComment),
             ("testCommentStartingWithPunctuation", testCommentStartingWithPunctuation),
-            ("testCommentEndingWithComma", testCommentEndingWithComma)
+            ("testCommentEndingWithComma", testCommentEndingWithComma),
+            ("testCommentWithNoWhiteSpaceToPunctuation", testCommentWithNoWhiteSpaceToPunctuation)
         ]
     }
 }


### PR DESCRIPTION
Attempting to fix failure in parsing comments correctly in some cases.

1. Punctuation before a `/*` or after a `*/`.
```swift
(/* */)
```

2. Punctuation before `//`
```swift
.// Hello
```

The PR manages to fix 1. and 2. without breaking any other tests.

The following doesn't succeed yet.
```swift
(/**/)
```

Can I get some guidance if maybe larger changes are needed to fix this in a good way. 
E.g. would having the check whether to merge delimiters benefit som support multiple characters (or maybe full `String`s)?

```swift
public func isDelimiter(_ delimiterA: Character, mergableWith delimiterB: Character) -> Bool {
```