### PR TITLE
Don’t highlight keywords used as parameters on a new line

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -78,6 +78,12 @@ private extension SwiftGrammar {
         "public", "internal", "fileprivate", "private"
     ]
 
+    static let declarationKeywords: Set<String> = [
+        "class", "struct", "enum", "func",
+        "protocol", "typealias", "import",
+        "associatedtype", "subscript"
+    ]
+
     struct PreprocessingRule: SyntaxRule {
         var tokenType: TokenType { return .preprocessing }
         private let controlFlowTokens: Set<String> = ["#if", "#endif", "#elseif", "#else"]
@@ -306,8 +312,8 @@ private extension SwiftGrammar {
                 }
             }
 
-            if !segment.tokens.onSameLine.isEmpty,
-               let previousToken = segment.tokens.previous {
+            if let previousToken = segment.tokens.previous,
+               !declarationKeywords.contains(segment.tokens.current) {
                 // Highlight the '(set)' part of setter access modifiers
                 switch segment.tokens.current {
                 case "(":
@@ -340,12 +346,6 @@ private extension SwiftGrammar {
 
     struct TypeRule: SyntaxRule {
         var tokenType: TokenType { return .type }
-
-        private let declarationKeywords: Set<String> = [
-            "class", "struct", "enum", "func",
-            "protocol", "typealias", "import",
-            "associatedtype", "subscript"
-        ]
 
         func matches(_ segment: Segment) -> Bool {
             // Types should not be highlighted when declared

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -88,6 +88,28 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithKeywordArgumentLabelOnNewLine() {
+        let components = highlighter.highlight("""
+        func a(
+            for b: B
+        )
+        """)
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("a("),
+            .whitespace("\n    "),
+            .plainText("for"),
+            .whitespace(" "),
+            .plainText("b:"),
+            .whitespace(" "),
+            .token("B", .type),
+            .whitespace("\n"),
+            .plainText(")")
+        ])
+    }
+
     func testGenericFunctionDeclarationWithKeywordArgumentLabel() {
         let components = highlighter.highlight("func perform<O: AnyObject>(for object: O) {}")
 
@@ -1056,6 +1078,7 @@ extension DeclarationTests {
             ("testPublicFunctionDeclarationWithDocumentationEndingWithDot", testPublicFunctionDeclarationWithDocumentationEndingWithDot),
             ("testFunctionDeclarationWithEmptyExternalLabel", testFunctionDeclarationWithEmptyExternalLabel),
             ("testFunctionDeclarationWithKeywordArgumentLabel", testFunctionDeclarationWithKeywordArgumentLabel),
+            ("testFunctionDeclarationWithKeywordArgumentLabelOnNewLine", testFunctionDeclarationWithKeywordArgumentLabelOnNewLine),
             ("testGenericFunctionDeclarationWithKeywordArgumentLabel", testGenericFunctionDeclarationWithKeywordArgumentLabel),
             ("testGenericFunctionDeclarationWithoutConstraints", testGenericFunctionDeclarationWithoutConstraints),
             ("testGenericFunctionDeclarationWithSingleConstraint", testGenericFunctionDeclarationWithSingleConstraint),


### PR DESCRIPTION
This patch fixes a bug that would cause Splash to incorrectly highlight parameter labels defined on a new line when those would match a keyword.