### PR TITLE
Support the ‘unowned’ keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -75,7 +75,7 @@ private extension SwiftGrammar {
         "lazy", "subscript", "defer", "inout", "while",
         "continue", "fallthrough", "repeat", "indirect",
         "deinit", "is", "#file", "#line", "#function",
-        "dynamic", "some", "#available", "convenience"
+        "dynamic", "some", "#available", "convenience", "unowned"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/ClosureTests.swift
+++ b/Tests/SplashTests/Tests/ClosureTests.swift
@@ -201,6 +201,46 @@ final class ClosureTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testClosureWithWeakSelfCaptureList() {
+        let components = highlighter.highlight("closure { [weak self] in }")
+
+        XCTAssertEqual(components, [
+            .token("closure", .call),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .plainText("["),
+            .token("weak", .keyword),
+            .whitespace(" "),
+            .token("self", .keyword),
+            .plainText("]"),
+            .whitespace(" "),
+            .token("in", .keyword),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
+    func testClosureWithUnownedSelfCaptureList() {
+        let components = highlighter.highlight("closure { [unowned self] in }")
+
+        XCTAssertEqual(components, [
+            .token("closure", .call),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .plainText("["),
+            .token("unowned", .keyword),
+            .whitespace(" "),
+            .token("self", .keyword),
+            .plainText("]"),
+            .whitespace(" "),
+            .token("in", .keyword),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -218,7 +258,9 @@ extension ClosureTests {
             ("testClosureWithInoutArgument", testClosureWithInoutArgument),
             ("testPassingClosureAsArgument", testPassingClosureAsArgument),
             ("testNestedEscapingClosure", testNestedEscapingClosure),
-            ("testClosureArgumentShorthands", testClosureArgumentShorthands)
+            ("testClosureArgumentShorthands", testClosureArgumentShorthands),
+            ("testClosureWithWeakSelfCaptureList", testClosureWithWeakSelfCaptureList),
+            ("testClosureWithUnownedSelfCaptureList", testClosureWithUnownedSelfCaptureList)
         ]
     }
 }


### PR DESCRIPTION
This change makes Splash correctly highlight the `unowned` keyword when used within closure capture lists.