### PR TITLE
Don’t highlight keyword names used in optional binding

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -322,31 +322,38 @@ private extension SwiftGrammar {
                 }
             }
 
-            if let previousToken = segment.tokens.previous,
-               !declarationKeywords.contains(segment.tokens.current) {
-                // Highlight the '(set)' part of setter access modifiers
-                switch segment.tokens.current {
-                case "(":
-                    return accessControlKeywords.contains(previousToken)
-                case "set":
-                    if previousToken == "(" {
-                        return true
-                    }
-                case ")":
-                    return previousToken == "set"
-                default:
-                    break
+            if let previousToken = segment.tokens.previous {
+                // Don't highlight variables with the same name as a keyword
+                // when used in optional binding, such as if let, guard let:
+                guard !previousToken.isAny(of: "let", "var") else {
+                    return false
                 }
 
-                // Don't highlight most keywords when used as a parameter label
-                if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout", "nil") {
-                    guard !previousToken.isAny(of: "(", ",", ">(") else {
+                if !declarationKeywords.contains(segment.tokens.current) {
+                    // Highlight the '(set)' part of setter access modifiers
+                    switch segment.tokens.current {
+                    case "(":
+                        return accessControlKeywords.contains(previousToken)
+                    case "set":
+                        if previousToken == "(" {
+                            return true
+                        }
+                    case ")":
+                        return previousToken == "set"
+                    default:
+                        break
+                    }
+
+                    // Don't highlight most keywords when used as a parameter label
+                    if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout", "nil") {
+                        guard !previousToken.isAny(of: "(", ",", ">(") else {
+                            return false
+                        }
+                    }
+
+                    guard !segment.tokens.previous.isAny(of: "func", "`") else {
                         return false
                     }
-                }
-
-                guard !segment.tokens.previous.isAny(of: "func", "`") else {
-                    return false
                 }
             }
 

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -62,6 +62,24 @@ final class StatementTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testIfLetStatementWithKeywordSymbolName() {
+        let components = highlighter.highlight("if let override = optional {}")
+
+        XCTAssertEqual(components, [
+            .token("if", .keyword),
+            .whitespace(" "),
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("override"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .plainText("optional"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testSwitchStatement() {
         let components = highlighter.highlight("""
         switch variable {
@@ -395,6 +413,7 @@ extension StatementTests {
             ("testImportStatement", testImportStatement),
             ("testImportStatementWithSubmodule", testImportStatementWithSubmodule),
             ("testChainedIfElseStatements", testChainedIfElseStatements),
+            ("testIfLetStatementWithKeywordSymbolName", testIfLetStatementWithKeywordSymbolName),
             ("testSwitchStatement", testSwitchStatement),
             ("testSwitchStatementWithSingleAssociatedValue", testSwitchStatementWithSingleAssociatedValue),
             ("testSwitchStatementWithMultipleAssociatedValues", testSwitchStatementWithMultipleAssociatedValues),


### PR DESCRIPTION
This patch makes Splash no longer highlight variables with the same name as a keyword when used in optional binding, for example:

```swift
if let override = makeOverride() { ... }
```