### PR TITLE
Handle string literals that only have a new line

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -506,9 +506,11 @@ private extension Segment {
         var previousToken: String?
 
         for token in tokens.onSameLine {
-            guard previousToken != "\\" else {
-                previousToken = token
-                continue
+            if token.hasPrefix("(") || token.hasPrefix("#(") || token.hasPrefix("\"") {
+                guard previousToken != "\\" else {
+                    previousToken = token
+                    continue
+                }
             }
 
             if token == start {

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -234,6 +234,19 @@ final class LiteralTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testStringLiteralContainingOnlyNewLine() {
+        let components = highlighter.highlight(#"text.split(separator: "\n")"#)
+
+        XCTAssertEqual(components, [
+            .plainText("text."),
+            .token("split", .call),
+            .plainText("(separator:"),
+            .whitespace(" "),
+            .token(#""\n""#, .string),
+            .plainText(")")
+        ])
+    }
+
     func testDoubleLiteral() {
         let components = highlighter.highlight("let double = 1.13")
 
@@ -320,6 +333,7 @@ extension LiteralTests {
             ("testSingleLineRawStringLiteral", testSingleLineRawStringLiteral),
             ("testMultiLineRawStringLiteral", testMultiLineRawStringLiteral),
             ("testRawStringWithInterpolation", testRawStringWithInterpolation),
+            ("testStringLiteralContainingOnlyNewLine", testStringLiteralContainingOnlyNewLine),
             ("testDoubleLiteral", testDoubleLiteral),
             ("testIntegerLiteralWithSeparators", testIntegerLiteralWithSeparators),
             ("testKeyPathLiteral", testKeyPathLiteral),


### PR DESCRIPTION
Since such new lines are grouped with their trailing marker, and start with an escaping backslash, they would previously be ignored (since they were incorrectly treated as string interpolation or escaped markers).