### PR TITLE
Fix regressions after keywords-in-optional binding change

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -325,8 +325,10 @@ private extension SwiftGrammar {
             if let previousToken = segment.tokens.previous {
                 // Don't highlight variables with the same name as a keyword
                 // when used in optional binding, such as if let, guard let:
-                guard !previousToken.isAny(of: "let", "var") else {
-                    return false
+                if !segment.tokens.onSameLine.isEmpty, segment.tokens.current != "self" {
+                    guard !previousToken.isAny(of: "let", "var") else {
+                        return false
+                    }
                 }
 
                 if !declarationKeywords.contains(segment.tokens.current) {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -691,6 +691,27 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testPropertyDeclarationAfterCommentEndingWithVarKeyword() {
+        let components = highlighter.highlight("""
+        // var
+        var number = 7
+        """)
+
+        XCTAssertEqual(components, [
+            .token("//", .comment),
+            .whitespace(" "),
+            .token("var", .comment),
+            .whitespace("\n"),
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("number"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("7", .number)
+        ])
+    }
+
     func testSubscriptDeclaration() {
         let components = highlighter.highlight("""
         extension Collection {
@@ -1102,6 +1123,7 @@ extension DeclarationTests {
             ("testPropertyDeclarationWithWillSet", testPropertyDeclarationWithWillSet),
             ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),
             ("testPropertyWithSetterAccessLevel", testPropertyWithSetterAccessLevel),
+            ("testPropertyDeclarationAfterCommentEndingWithVarKeyword", testPropertyDeclarationAfterCommentEndingWithVarKeyword),
             ("testSubscriptDeclaration", testSubscriptDeclaration),
             ("testGenericSubscriptDeclaration", testGenericSubscriptDeclaration),
             ("testDeferDeclaration", testDeferDeclaration),

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -80,6 +80,26 @@ final class StatementTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testGuardStatementUnwrappingWeakSelf() {
+        let components = highlighter.highlight("guard let self = self else {}")
+
+        XCTAssertEqual(components, [
+            .token("guard", .keyword),
+            .whitespace(" "),
+            .token("let", .keyword),
+            .whitespace(" "),
+            .token("self", .keyword),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("self", .keyword),
+            .whitespace(" "),
+            .token("else", .keyword),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testSwitchStatement() {
         let components = highlighter.highlight("""
         switch variable {
@@ -414,6 +434,7 @@ extension StatementTests {
             ("testImportStatementWithSubmodule", testImportStatementWithSubmodule),
             ("testChainedIfElseStatements", testChainedIfElseStatements),
             ("testIfLetStatementWithKeywordSymbolName", testIfLetStatementWithKeywordSymbolName),
+            ("testGuardStatementUnwrappingWeakSelf", testGuardStatementUnwrappingWeakSelf),
             ("testSwitchStatement", testSwitchStatement),
             ("testSwitchStatementWithSingleAssociatedValue", testSwitchStatementWithSingleAssociatedValue),
             ("testSwitchStatementWithMultipleAssociatedValues", testSwitchStatementWithMultipleAssociatedValues),


### PR DESCRIPTION
This patch fixes two regressions caused by the recently introduced change to not highlight keywords used as symbol names when binding optionals:

1. When a weak reference to `self` is unwrapped using a `guard` statement.
2. When a property declaration is placed after a comment ending with “var”.