### PR TITLE
Fix Swift 5.2 compiler crash

### DIFF
--- a/Sources/Splash/Theming/Font.swift
+++ b/Sources/Splash/Theming/Font.swift
@@ -70,14 +70,11 @@ internal extension Font {
     }
 
     private func load(fromPath path: String) -> Loaded? {
-        let url = CFURLCreateWithFileSystemPath(
-            kCFAllocatorDefault,
-            path as CFString,
-            .cfurlposixPathStyle,
-            false
-        )
-
-        guard let font = url.flatMap(CGDataProvider.init).flatMap(CGFont.init) else {
+        guard
+            let url = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, path as CFString, .cfurlposixPathStyle, false),
+            let provider = CGDataProvider(url: url),
+            let font = CGFont(provider)
+        else {
             return nil
         }
 


### PR DESCRIPTION
Splash was making Xcode 11.4 beta 1 throw a segmentation fault. The crash was solved by not using “fancy” `.flatMap` on optional when creating a `CGFont`, but rather a multistep guard statement.