### PR TITLE
Correctly highlight enum cases called “some”

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -307,6 +307,12 @@ private extension SwiftGrammar {
                 return true
             }
 
+            if segment.tokens.current == "some" {
+                guard segment.tokens.previous != "case" else {
+                    return false
+                }
+            }
+
             if segment.tokens.next == ":" {
                 // Nil pattern matching inside of a switch statement case
                 if segment.tokens.current == "nil" {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -1023,6 +1023,26 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testEnumDeclarationWithSomeCase() {
+        let components = highlighter.highlight("""
+        enum MyEnum { case some }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("enum", .keyword),
+            .whitespace(" "),
+            .plainText("MyEnum"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("case", .keyword),
+            .whitespace(" "),
+            .plainText("some"),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testIndirectEnumDeclaration() {
         let components = highlighter.highlight("""
         indirect enum Content {
@@ -1135,6 +1155,7 @@ extension DeclarationTests {
             ("testRethrowingFunctionDeclaration", testRethrowingFunctionDeclaration),
             ("testFunctionDeclarationWithOpaqueReturnType", testFunctionDeclarationWithOpaqueReturnType),
             ("testPrefixFunctionDeclaration", testPrefixFunctionDeclaration),
+            ("testEnumDeclarationWithSomeCase", testEnumDeclarationWithSomeCase),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration),
             ("testWrappedPropertyDeclarations", testWrappedPropertyDeclarations)
         ]


### PR DESCRIPTION
Was previously highlighted as a keyword.