### PR TITLE
[ADD] option to specify a grammar for MarkdownDecorator

### DIFF
--- a/Sources/Splash/Output/MarkdownDecorator.swift
+++ b/Sources/Splash/Output/MarkdownDecorator.swift
@@ -13,8 +13,8 @@ public struct MarkdownDecorator {
 
     /// Create a Markdown decorator with a given prefix to apply to all CSS
     /// classes used when highlighting code blocks within a Markdown string.
-    public init(classPrefix: String = "") {
-        highlighter = SyntaxHighlighter(format: HTMLOutputFormat(classPrefix: classPrefix))
+    public init(classPrefix: String = "", grammar: Grammar = SwiftGrammar()) {
+        highlighter = SyntaxHighlighter(format: HTMLOutputFormat(classPrefix: classPrefix), grammar: grammar)
     }
 
     /// Decorate all code blocks within a given Markdown string. This API assumes


### PR DESCRIPTION
`MarkdownDecorator` currently always uses `SwiftGrammar` for highlighting, making using it to highlight markdown documents containing code written in another language a bit problematic. This PR just adds the parameter `grammar` so we can inject any `Grammar`.

Splash has been of great help recently, I hope you'll consider this change 😊