### PR TITLE
Fix syntax highlighting for leading function calls within closures

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -231,6 +231,7 @@ private extension SwiftGrammar {
             keywordsToAvoid.remove("try")
             keywordsToAvoid.remove("throw")
             keywordsToAvoid.remove("if")
+            keywordsToAvoid.remove("in")
             self.keywordsToAvoid = keywordsToAvoid
 
             var callLikeKeywords = accessControlKeywords

--- a/Tests/SplashTests/Tests/ClosureTests.swift
+++ b/Tests/SplashTests/Tests/ClosureTests.swift
@@ -241,6 +241,25 @@ final class ClosureTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testClosureWithSingleFunctionCall() {
+        let components = highlighter.highlight("closure { a in call(a) }")
+
+        XCTAssertEqual(components, [
+            .token("closure", .call),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .plainText("a"),
+            .whitespace(" "),
+            .token("in", .keyword),
+            .whitespace(" "),
+            .token("call", .call),
+            .plainText("(a)"),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -260,7 +279,8 @@ extension ClosureTests {
             ("testNestedEscapingClosure", testNestedEscapingClosure),
             ("testClosureArgumentShorthands", testClosureArgumentShorthands),
             ("testClosureWithWeakSelfCaptureList", testClosureWithWeakSelfCaptureList),
-            ("testClosureWithUnownedSelfCaptureList", testClosureWithUnownedSelfCaptureList)
+            ("testClosureWithUnownedSelfCaptureList", testClosureWithUnownedSelfCaptureList),
+            ("testClosureWithSingleFunctionCall", testClosureWithSingleFunctionCall)
         ]
     }
 }


### PR DESCRIPTION
This patch fixes syntax highlighting when a function call appears as the first expression within a closure that accepts arguments or capture lists using the ‘in’ keyword.