### PR TITLE
Don’t treat accessing properties within switch statements as calls

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -223,7 +223,7 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .call }
         private let keywordsToAvoid: Set<String>
         private let callLikeKeywords: Set<String>
-        private let controlFlowTokens = ["if", "&&", "||", "for"]
+        private let controlFlowTokens = ["if", "&&", "||", "for", "switch"]
 
         init() {
             var keywordsToAvoid = keywords

--- a/Tests/SplashTests/Tests/StatementTests.swift
+++ b/Tests/SplashTests/Tests/StatementTests.swift
@@ -315,6 +315,28 @@ final class StatementTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testSwitchStatementWithProperty() {
+        let components = highlighter.highlight("""
+        switch object.value { default: break }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("switch", .keyword),
+            .whitespace(" "),
+            .plainText("object."),
+            .token("value", .property),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .token("default", .keyword),
+            .plainText(":"),
+            .whitespace(" "),
+            .token("break", .keyword),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testForStatementWithStaticProperty() {
         let components = highlighter.highlight("for value in Enum.allCases { }")
 
@@ -441,6 +463,7 @@ extension StatementTests {
             ("testSwitchStatementWithFallthrough", testSwitchStatementWithFallthrough),
             ("testSwitchStatementWithTypePatternMatching", testSwitchStatementWithTypePatternMatching),
             ("testSwitchStatementWithOptional", testSwitchStatementWithOptional),
+            ("testSwitchStatementWithProperty", testSwitchStatementWithProperty),
             ("testForStatementWithStaticProperty", testForStatementWithStaticProperty),
             ("testForStatementWithContinue", testForStatementWithContinue),
             ("testRepeatWhileStatement", testRepeatWhileStatement),


### PR DESCRIPTION
This patch fixes syntax highlighting for when a property is being switched on, which previously would be treated as a function call with trailing closure syntax.