### PR TITLE
Correctly highlight the “try” keyword when used within a function call

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -354,7 +354,7 @@ private extension SwiftGrammar {
                     }
 
                     // Don't highlight most keywords when used as a parameter label
-                    if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout", "nil") {
+                    if !segment.tokens.current.isAny(of: "_", "self", "let", "var", "true", "false", "inout", "nil", "try") {
                         guard !previousToken.isAny(of: "(", ",", ">(") else {
                             return false
                         }

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -170,6 +170,19 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testUsingTryKeywordWithinFunctionCall() {
+        let components = highlighter.highlight("XCTAssertThrowsError(try function())")
+
+        XCTAssertEqual(components, [
+            .token("XCTAssertThrowsError", .call),
+            .plainText("("),
+            .token("try", .keyword),
+            .whitespace(" "),
+            .token("function", .call),
+            .plainText("())")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -189,7 +202,8 @@ extension FunctionCallTests {
             ("testPassingTypeToFunction", testPassingTypeToFunction),
             ("testPassingBoolToUnnamedArgument", testPassingBoolToUnnamedArgument),
             ("testIndentedFunctionCalls", testIndentedFunctionCalls),
-            ("testXCTAssertCalls", testXCTAssertCalls)
+            ("testXCTAssertCalls", testXCTAssertCalls),
+            ("testUsingTryKeywordWithinFunctionCall", testUsingTryKeywordWithinFunctionCall)
         ]
     }
 }


### PR DESCRIPTION
This change makes Splash highlight the `try` keyword when it appears within a function’s argument list.