### PR TITLE
Fix highlighting for comments that appear next to curly brackets

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -55,6 +55,8 @@ public struct SwiftGrammar: Grammar {
             return false
         case (".", "/"):
             return false
+        case ("{", "/"), ("}", "/"):
+            return false
         default:
             return true
         }

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -173,6 +173,23 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCommentsNextToCurlyBrackets() {
+        let components = highlighter.highlight("""
+        call {//commentA
+        }//commentB
+        """)
+
+        XCTAssertEqual(components, [
+            .token("call", .call),
+            .whitespace(" "),
+            .plainText("{"),
+            .token("//commentA", .comment),
+            .whitespace("\n"),
+            .plainText("}"),
+            .token("//commentB", .comment)
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -188,7 +205,8 @@ extension CommentTests {
             ("testCommentStartingWithPunctuation", testCommentStartingWithPunctuation),
             ("testCommentEndingWithComma", testCommentEndingWithComma),
             ("testCommentWithNumber", testCommentWithNumber),
-            ("testCommentWithNoWhiteSpaceToPunctuation", testCommentWithNoWhiteSpaceToPunctuation)
+            ("testCommentWithNoWhiteSpaceToPunctuation", testCommentWithNoWhiteSpaceToPunctuation),
+            ("testCommentsNextToCurlyBrackets", testCommentsNextToCurlyBrackets)
         ]
     }
 }


### PR DESCRIPTION
This change makes Splash correctly highlight comments that are placed right next to either an opening or closing curly bracket.