### PR TITLE
Don’t highlight generic parameter types used in initializer declarations

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -87,7 +87,7 @@ private extension SwiftGrammar {
     static let declarationKeywords: Set<String> = [
         "class", "struct", "enum", "func",
         "protocol", "typealias", "import",
-        "associatedtype", "subscript"
+        "associatedtype", "subscript", "init"
     ]
 
     struct PreprocessingRule: SyntaxRule {

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -1106,6 +1106,35 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testGenericInitializerDeclaration() {
+        let components = highlighter.highlight("""
+        struct Box {
+            init<T: Model>(model: T) {}
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Box"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("init", .keyword),
+            .plainText("<T:"),
+            .whitespace(" "),
+            .token("Model", .type),
+            .plainText(">(model:"),
+            .whitespace(" "),
+            .token("T", .type),
+            .plainText(")"),
+            .whitespace(" "),
+            .plainText("{}"),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -1157,7 +1186,8 @@ extension DeclarationTests {
             ("testPrefixFunctionDeclaration", testPrefixFunctionDeclaration),
             ("testEnumDeclarationWithSomeCase", testEnumDeclarationWithSomeCase),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration),
-            ("testWrappedPropertyDeclarations", testWrappedPropertyDeclarations)
+            ("testWrappedPropertyDeclarations", testWrappedPropertyDeclarations),
+            ("testGenericInitializerDeclaration", testGenericInitializerDeclaration)
         ]
     }
 }


### PR DESCRIPTION
This change makes Splash stop highlighting generic types that are attached to an initializer declaration, and instead now only highlights their constraints, just like within other kinds of generic type lists.