### PR TITLE
Correctly highlight subclasses inheriting from a generic superclass

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -419,7 +419,7 @@ private extension SwiftGrammar {
                     }
 
                     // Handling generic lists for parameters, rather than declarations
-                    if foundOpeningBracket && token == ":" {
+                    if foundOpeningBracket && token.isAny(of: ":", ">:") {
                         return true
                     }
 

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -368,6 +368,23 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testGenericSubclassDeclaration() {
+        let components = highlighter.highlight("class Promise<Value>: Future<Value> {}")
+
+        XCTAssertEqual(components, [
+            .token("class", .keyword),
+            .whitespace(" "),
+            .plainText("Promise<Value>:"),
+            .whitespace(" "),
+            .token("Future", .type),
+            .plainText("<"),
+            .token("Value", .type),
+            .plainText(">"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
     func testProtocolDeclaration() {
         let components = highlighter.highlight("""
         protocol Hello {
@@ -1132,6 +1149,7 @@ extension DeclarationTests {
             ("testClassDeclarationWithDeinit", testClassDeclarationWithDeinit),
             ("testClassDeclarationWithMultipleProtocolConformances", testClassDeclarationWithMultipleProtocolConformances),
             ("testSubclassDeclaration", testSubclassDeclaration),
+            ("testGenericSubclassDeclaration", testGenericSubclassDeclaration),
             ("testProtocolDeclaration", testProtocolDeclaration),
             ("testProtocolDeclarationWithAssociatedTypes", testProtocolDeclarationWithAssociatedTypes),
             ("testExtensionDeclaration", testExtensionDeclaration),


### PR DESCRIPTION
This change fixes syntax highlighting in situations when a subclass is inheriting from a superclass that’s generic.