### PR TITLE
Allow initializing `Font` with `NSFont` or `UIFont`

### DIFF
--- a/Sources/Splash/Theming/Font.swift
+++ b/Sources/Splash/Theming/Font.swift
@@ -31,6 +31,12 @@ public struct Font {
         resource = .system
         self.size = size
     }
+    
+    /// Initialize an instance with an existing, custom, font.
+    public init(font: Loaded) {
+        resource = .preloaded(font)
+        self.size = font.pointSize
+    }
 }
 
 public extension Font {


### PR DESCRIPTION
This would allow using a custom monospace font for highlighting. Which is especially useful if, say, the code is embedded into some sort of *presentation* 😊. An assert could be added to make sure the font is monospace, but I feel like that's not required. If [somebody wants to display their code in Comic Sans](https://www.reddit.com/r/Unity3D/comments/57cu1e/been_using_comic_sans_as_font_in_code_editor/), all the more power to them