### PR TITLE
Support nested property wrappers

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -139,7 +139,21 @@ private extension SwiftGrammar {
         var tokenType: TokenType { return .keyword }
 
         func matches(_ segment: Segment) -> Bool {
-            return segment.tokens.current.hasPrefix("@")
+            if segment.tokens.current.hasPrefix("@") {
+                return true
+            }
+
+            if segment.tokens.previous == "." {
+                let suffix = segment.tokens.onSameLine.suffix(2)
+
+                guard suffix.count == 2 else {
+                    return false
+                }
+
+                return suffix.first?.hasPrefix("@") ?? false
+            }
+
+            return false
         }
     }
 

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -1123,6 +1123,34 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testWrappedPropertyDeclarationUsingNestedType() {
+        let components = highlighter.highlight("""
+        struct User {
+            @Persisted.InMemory var name: String
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("User"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("@Persisted", .keyword),
+            .plainText("."),
+            .token("InMemory", .keyword),
+            .whitespace(" "),
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("name:"),
+            .whitespace(" "),
+            .token("String", .type),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testGenericInitializerDeclaration() {
         let components = highlighter.highlight("""
         struct Box {
@@ -1205,6 +1233,7 @@ extension DeclarationTests {
             ("testEnumDeclarationWithSomeCase", testEnumDeclarationWithSomeCase),
             ("testIndirectEnumDeclaration", testIndirectEnumDeclaration),
             ("testWrappedPropertyDeclarations", testWrappedPropertyDeclarations),
+            ("testWrappedPropertyDeclarationUsingNestedType", testWrappedPropertyDeclarationUsingNestedType),
             ("testGenericInitializerDeclaration", testGenericInitializerDeclaration)
         ]
     }


### PR DESCRIPTION
This change makes Splash correctly highlight property wrappers that are using nested types, for example `@My.PropertyWrapper`.