### PR TITLE
Correctly highlight projected property wrapper values

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -625,6 +625,6 @@ private extension Segment {
             return false
         }
 
-        return firstCharacter == "_" || firstCharacter.isLetter
+        return firstCharacter == "_" || firstCharacter == "$" || firstCharacter.isLetter
     }
 }

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -183,6 +183,19 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCallingFunctionWithProjectedPropertyWrapperValue() {
+        let components = highlighter.highlight("call(self.$value)")
+
+        XCTAssertEqual(components, [
+            .token("call", .call),
+            .plainText("("),
+            .token("self", .keyword),
+            .plainText("."),
+            .token("$value", .property),
+            .plainText(")")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -203,7 +216,8 @@ extension FunctionCallTests {
             ("testPassingBoolToUnnamedArgument", testPassingBoolToUnnamedArgument),
             ("testIndentedFunctionCalls", testIndentedFunctionCalls),
             ("testXCTAssertCalls", testXCTAssertCalls),
-            ("testUsingTryKeywordWithinFunctionCall", testUsingTryKeywordWithinFunctionCall)
+            ("testUsingTryKeywordWithinFunctionCall", testUsingTryKeywordWithinFunctionCall),
+            ("testCallingFunctionWithProjectedPropertyWrapperValue", testCallingFunctionWithProjectedPropertyWrapperValue)
         ]
     }
 }


### PR DESCRIPTION
Such as when passing a property wrapper using `self.$value`.