### PR TITLE
Fix build product path to work on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 install:
 	swift package update
 	swift build -c release
-	install .build/Release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
-	install .build/Release/SplashMarkdown /usr/local/bin/SplashMarkdown
-	install .build/Release/SplashImageGen /usr/local/bin/SplashImageGen
-	install .build/Release/SplashTokenizer /usr/local/bin/SplashTokenizer
+	install .build/release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
+	install .build/release/SplashMarkdown /usr/local/bin/SplashMarkdown
+	install .build/release/SplashImageGen /usr/local/bin/SplashImageGen
+	install .build/release/SplashTokenizer /usr/local/bin/SplashTokenizer

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ If you want to use Splash through one of its built-in command line tools, start 
 
 ```
 $ git clone https://github.com/johnsundell/splash.git
-$ cd Splash
+$ cd splash
 ```
 
 To run a tool without installing it, you can use the Swift Package Manager's `run` command, like this:
@@ -191,7 +191,7 @@ If you only wish to install one of these, compile it and then move it to `/usr/l
 
 ```
 $ swift build -c release -Xswiftc -static-stdlib
-$ install .build/Release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
+$ install .build/release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
 ```
 
 ## Contributions and support


### PR DESCRIPTION
## Summary of the bug

On some systems, where folder names are strictly case sensitive, installation fails because it's unable to find `Release` directory. In my case that manifested when trying to deploy on Netlify, which uses Ubuntu. 

```
8:34:16 PM: $ sh scripts/build.sh
8:34:16 PM: Cloning into 'splash'...
8:34:17 PM: swift package update
8:34:29 PM: Everything is already up-to-date
8:34:29 PM: swift build -c release
8:34:37 PM: [1/5] Compiling Splash CharacterSet+Contains.swift
8:34:37 PM: [2/9] Compiling SplashImageGen CGImage+WriteToURL.swift
8:34:37 PM: [3/9] Compiling SplashHTMLGen main.swift
8:34:37 PM: [4/9] Linking SplashImageGen
8:34:37 PM: [5/9] Compiling SplashMarkdown main.swift
8:34:38 PM: [6/9] Linking SplashHTMLGen
8:34:38 PM: [7/9] Compiling SplashTokenizer TokenizerOutputFormat.swift
8:34:38 PM: [8/9] Linking SplashMarkdown
8:34:38 PM: [9/9] Linking SplashTokenizer
8:34:38 PM: install .build/Release/SplashHTMLGen /usr/local/bin/SplashHTMLGen
8:34:38 PM: install: cannot stat '.build/Release/SplashHTMLGen': No such file or directory
```

## The fix 

The real directory name is lowercase `.build/release`, after the build configuration name. 
On macOS, both `cd Release` and `cd release` work, for example, but not on Ubuntu. 
With this fix, everything works like a charm on both macOS and Linux. 
