### PR TITLE
Fix highlighting for static properties/enum cases on generic types

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -503,7 +503,7 @@ private extension SwiftGrammar {
                 return false
             }
 
-            guard segment.tokens.previous.isAny(of: ".", "?.", "().", ").") else {
+            guard segment.tokens.previous.isAny(of: ".", "?.", "().", ").", ">.") else {
                 return false
             }
 

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -729,6 +729,36 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testPropertyDeclarationWithStaticPropertyDefaultValue() {
+        let components = highlighter.highlight("""
+        class ViewModel {
+            var state = LoadingState<Output>.idle
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("class", .keyword),
+            .whitespace(" "),
+            .plainText("ViewModel"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("state"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("LoadingState", .type),
+            .plainText("<"),
+            .token("Output", .type),
+            .plainText(">."),
+            .token("idle", .property),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testSubscriptDeclaration() {
         let components = highlighter.highlight("""
         extension Collection {
@@ -1277,6 +1307,7 @@ extension DeclarationTests {
             ("testPropertyDeclarationWithDidSet", testPropertyDeclarationWithDidSet),
             ("testPropertyWithSetterAccessLevel", testPropertyWithSetterAccessLevel),
             ("testPropertyDeclarationAfterCommentEndingWithVarKeyword", testPropertyDeclarationAfterCommentEndingWithVarKeyword),
+            ("testPropertyDeclarationWithStaticPropertyDefaultValue", testPropertyDeclarationWithStaticPropertyDefaultValue),
             ("testSubscriptDeclaration", testSubscriptDeclaration),
             ("testGenericSubscriptDeclaration", testGenericSubscriptDeclaration),
             ("testDeferDeclaration", testDeferDeclaration),


### PR DESCRIPTION
This patch makes Splash correctly render enum cases and static properties that are defined on a generic type when those symbols are references along with their enclosing type.