### PR TITLE
Fix highlighting for method calls named the same as a keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -305,8 +305,10 @@ private extension SwiftGrammar {
                     return false
                 }
 
-                guard !keywords.contains(segment.tokens.current) else {
-                    return false
+                if segment.tokens.previous != "." {
+                    guard !keywords.contains(segment.tokens.current) else {
+                        return false
+                    }
                 }
 
                 return !segment.tokens.onSameLine.contains(anyOf: controlFlowTokens)

--- a/Tests/SplashTests/Tests/FunctionCallTests.swift
+++ b/Tests/SplashTests/Tests/FunctionCallTests.swift
@@ -196,6 +196,23 @@ final class FunctionCallTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCallingMethodWithSameNameAsKeywordWithTrailingClosureSyntax() {
+        let components = highlighter.highlight("publisher.catch { error in }")
+
+        XCTAssertEqual(components, [
+            .plainText("publisher."),
+            .token("catch", .call),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace(" "),
+            .plainText("error"),
+            .whitespace(" "),
+            .token("in", .keyword),
+            .whitespace(" "),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -217,7 +234,8 @@ extension FunctionCallTests {
             ("testIndentedFunctionCalls", testIndentedFunctionCalls),
             ("testXCTAssertCalls", testXCTAssertCalls),
             ("testUsingTryKeywordWithinFunctionCall", testUsingTryKeywordWithinFunctionCall),
-            ("testCallingFunctionWithProjectedPropertyWrapperValue", testCallingFunctionWithProjectedPropertyWrapperValue)
+            ("testCallingFunctionWithProjectedPropertyWrapperValue", testCallingFunctionWithProjectedPropertyWrapperValue),
+            ("testCallingMethodWithSameNameAsKeywordWithTrailingClosureSyntax", testCallingMethodWithSameNameAsKeywordWithTrailingClosureSyntax)
         ]
     }
 }


### PR DESCRIPTION
When those calls are made using trailing closure syntax.