### PR TITLE
Improve highlighting of comments when placed next to symbols

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -57,6 +57,8 @@ public struct SwiftGrammar: Grammar {
             return false
         case ("{", "/"), ("}", "/"):
             return false
+        case (">", "/"), ("?", "/"):
+            return false
         default:
             return true
         }
@@ -424,14 +426,14 @@ private extension SwiftGrammar {
             }
 
             // In a generic declaration, only highlight constraints
-            if segment.tokens.previous.isAny(of: "<", ",") {
+            if segment.tokens.previous.isAny(of: "<", ",", "*/") {
                 var foundOpeningBracket = false
 
                 // Since the declaration might be on another line, we have to walk
                 // backwards through all tokens until we've found enough information.
                 for token in segment.tokens.all.reversed() {
                     // Highlight return type generics as normal
-                    if token == "->" {
+                    if token.isAny(of: "->", ">", ">:") {
                         return true
                     }
 
@@ -441,7 +443,7 @@ private extension SwiftGrammar {
 
                     // Handling generic lists for parameters, rather than declarations
                     if foundOpeningBracket {
-                        if token.isAny(of: ":", ">:") || token.first == "@" {
+                        if token.isAny(of: ":") || token.first == "@" {
                             return true
                         }
                     }
@@ -456,7 +458,7 @@ private extension SwiftGrammar {
                         return true
                     }
 
-                    if token.isAny(of: ">", "=", "==", "(") {
+                    if token.isAny(of: "=", "==", "(") {
                         return true
                     }
                 }

--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -443,7 +443,7 @@ private extension SwiftGrammar {
 
                     // Handling generic lists for parameters, rather than declarations
                     if foundOpeningBracket {
-                        if token.isAny(of: ":") || token.first == "@" {
+                        if token == ":" || token.first == "@" {
                             return true
                         }
                     }

--- a/Tests/SplashTests/Tests/CommentTests.swift
+++ b/Tests/SplashTests/Tests/CommentTests.swift
@@ -219,6 +219,109 @@ final class CommentTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testCommentWithinGenericTypeList() {
+        let components = highlighter.highlight("""
+        struct Box<One, /*Comment*/Two: Equatable, Three> {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Box<One,"),
+            .whitespace(" "),
+            .token("/*Comment*/", .comment),
+            .plainText("Two:"),
+            .whitespace(" "),
+            .token("Equatable", .type),
+            .plainText(","),
+            .whitespace(" "),
+            .plainText("Three>"),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
+    func testCommentsNextToGenericTypeList() {
+        let components = highlighter.highlight("""
+        struct Box/*Start*/<Content>/*End*/ {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Box"),
+            .token("/*Start*/", .comment),
+            .plainText("<Content>"),
+            .token("/*End*/", .comment),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
+    func testCommentsNextToInitialization() {
+        let components = highlighter.highlight("/*Start*/Object()/*End*/")
+
+        XCTAssertEqual(components, [
+            .token("/*Start*/", .comment),
+            .token("Object", .type),
+            .plainText("()"),
+            .token("/*End*/", .comment)
+        ])
+    }
+
+    func testCommentsNextToProtocolName() {
+        let components = highlighter.highlight("""
+        struct Model<Value>: /*Start*/Equatable/*End*/ {}
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Model<Value>:"),
+            .whitespace(" "),
+            .token("/*Start*/", .comment),
+            .token("Equatable", .type),
+            .token("/*End*/", .comment),
+            .whitespace(" "),
+            .plainText("{}")
+        ])
+    }
+
+    func testCommentsAfterOptionalTypes() {
+        let components = highlighter.highlight("""
+        struct Model {
+            var one: String?//One
+            var two: String?/*Two*/
+        }
+        """)
+
+        XCTAssertEqual(components, [
+            .token("struct", .keyword),
+            .whitespace(" "),
+            .plainText("Model"),
+            .whitespace(" "),
+            .plainText("{"),
+            .whitespace("\n    "),
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("one:"),
+            .whitespace(" "),
+            .token("String", .type),
+            .plainText("?"),
+            .token("//One", .comment),
+            .whitespace("\n    "),
+            .token("var", .keyword),
+            .whitespace(" "),
+            .plainText("two:"),
+            .whitespace(" "),
+            .token("String", .type),
+            .plainText("?"),
+            .token("/*Two*/", .comment),
+            .whitespace("\n"),
+            .plainText("}")
+        ])
+    }
+
     func testAllTestsRunOnLinux() {
         XCTAssertTrue(TestCaseVerifier.verifyLinuxTests((type(of: self)).allTests))
     }
@@ -236,7 +339,12 @@ extension CommentTests {
             ("testCommentPrecededByComma", testCommentPrecededByComma),
             ("testCommentWithNumber", testCommentWithNumber),
             ("testCommentWithNoWhiteSpaceToPunctuation", testCommentWithNoWhiteSpaceToPunctuation),
-            ("testCommentsNextToCurlyBrackets", testCommentsNextToCurlyBrackets)
+            ("testCommentsNextToCurlyBrackets", testCommentsNextToCurlyBrackets),
+            ("testCommentWithinGenericTypeList", testCommentWithinGenericTypeList),
+            ("testCommentsNextToGenericTypeList", testCommentsNextToGenericTypeList),
+            ("testCommentsNextToInitialization", testCommentsNextToInitialization),
+            ("testCommentsNextToProtocolName", testCommentsNextToProtocolName),
+            ("testCommentsAfterOptionalTypes", testCommentsAfterOptionalTypes)
         ]
     }
 }


### PR DESCRIPTION
Especially for multi-line comments placed next to generic type lists.