### PR TITLE
Remove reference to shuttered https://splash.rambo.codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ Splash can be used either as a library in your own Swift Package Manager-powered
 
 ### 🌍 On the web
 
-Thanks to my good friend [Gui Rambo](https://twitter.com/_inside), you can [try out Splash directly in your browser](https://splash.rambo.codes)! His web tool lets you use Splash to generate either HTML or an image, by simply pasting Swift code into a text box.
-
-👉 [splash.rambo.codes](https://splash.rambo.codes)
-
 If you're using [Publish](https://github.com/JohnSundell/Publish), then there's an official plugin that makes it easy to integrate Splash into your website:
 
 👉 [SplashPublishPlugin](https://github.com/JohnSundell/SplashPublishPlugin)


### PR DESCRIPTION
https://splash.rambo.codes seems to be gone; might as well remove it from the readme.