### PR TITLE
Add executables definition to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,11 @@ import PackageDescription
 let package = Package(
     name: "Splash",
     products: [
-        .library(name: "Splash", targets: ["Splash"])
+        .library(name: "Splash", targets: ["Splash"]),
+        .executable(name: "SplashMarkdown", targets: ["SplashMarkdown"]),
+        .executable(name: "SplashHTMLGen", targets: ["SplashHTMLGen"]),
+        .executable(name: "SplashImageGen", targets: ["SplashImageGen"]),
+        .executable(name: "SplashTokenizer", targets: ["SplashTokenizer"]),
     ],
     targets: [
         .target(name: "Splash"),


### PR DESCRIPTION
Interestingly enough, the project works without defining these executables in the Package definition, however, this makes it explicit that Splash exports executables.

To be completely honest, I felt the need to add these because it makes it easier to install Splash using the Mint package manager, and these were all the necessary changes.