### PR TITLE
Add `ImageIO` import allowing to build the tool using recent toolchain

### DIFF
--- a/Sources/SplashImageGen/Extensions/CGImage+WriteToURL.swift
+++ b/Sources/SplashImageGen/Extensions/CGImage+WriteToURL.swift
@@ -7,6 +7,7 @@
 #if os(macOS)
 
 import Foundation
+import ImageIO
 
 extension CGImage {
     func write(to url: URL) {


### PR DESCRIPTION
Should resolve:
```
error: cannot find 'CGImageDestinationCreateWithURL' in scope
```
build errors.