### PR TITLE
Add support for the 'any' keyword

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -82,7 +82,7 @@ private extension SwiftGrammar {
         "continue", "fallthrough", "repeat", "indirect",
         "deinit", "is", "#file", "#line", "#function",
         "dynamic", "some", "#available", "convenience", "unowned",
-        "async", "await", "actor"
+        "async", "await", "actor", "any"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -1104,6 +1104,21 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithAnyParameter() {
+        let components = highlighter.highlight("func process(value: any Value)")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("process(value:"),
+            .whitespace(" "),
+            .token("any", .keyword),
+            .whitespace(" "),
+            .token("Value", .type),
+            .plainText(")")
+        ])
+    }
+
     func testPrefixFunctionDeclaration() {
         let components = highlighter.highlight("prefix func !(rhs: Bool) -> Bool { !rhs }")
 


### PR DESCRIPTION
The newly added `any` keyword is now correctly highlighted.