### PR TITLE
Correctly highlight the 'any' keyword when used within other type references

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -342,7 +342,7 @@ private extension SwiftGrammar {
                 return true
             }
 
-            if segment.tokens.current == "some" {
+            if segment.tokens.current.isAny(of: "some", "any") {
                 guard segment.tokens.previous != "case" else {
                     return false
                 }

--- a/Tests/SplashTests/Tests/DeclarationTests.swift
+++ b/Tests/SplashTests/Tests/DeclarationTests.swift
@@ -1119,6 +1119,44 @@ final class DeclarationTests: SyntaxHighlighterTestCase {
         ])
     }
 
+    func testFunctionDeclarationWithGenericAnyParameter() {
+        let components = highlighter.highlight("func process(collection: any Collection<any Value>)")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("process(collection:"),
+            .whitespace(" "),
+            .token("any", .keyword),
+            .whitespace(" "),
+            .token("Collection", .type),
+            .plainText("<"),
+            .token("any", .keyword),
+            .whitespace(" "),
+            .token("Value", .type),
+            .plainText(">)")
+        ])
+    }
+
+    func testFunctionDeclarationWithAnyDictionary() {
+        let components = highlighter.highlight("func process(dictionary: [String: any Value])")
+
+        XCTAssertEqual(components, [
+            .token("func", .keyword),
+            .whitespace(" "),
+            .plainText("process(dictionary:"),
+            .whitespace(" "),
+            .plainText("["),
+            .token("String", .type),
+            .plainText(":"),
+            .whitespace(" "),
+            .token("any", .keyword),
+            .whitespace(" "),
+            .token("Value", .type),
+            .plainText("])")
+        ])
+    }
+
     func testPrefixFunctionDeclaration() {
         let components = highlighter.highlight("prefix func !(rhs: Bool) -> Bool { !rhs }")
 


### PR DESCRIPTION
Treat it the same way as the `some` keyword.