### PR TITLE
Add multi line text interpolation support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:6.0
 
 /**
  *  Splash

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 #if !os(Linux)
-
+import AppKit
 /// A theme describes what fonts and colors to use when rendering
 /// certain output formats - such as `NSAttributedString`. Several
 /// default implementations are provided - see Theme+Defaults.swift.

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -168,6 +168,78 @@ final class LiteralTests: SyntaxHighlighterTestCase {
             .token("\"\"\"", .string)
         ])
     }
+    
+    func testMultiLineStringLiteralWithMultiLineInterpolated() {
+        let components = highlighter.highlight("""
+        let string = \"\"\"
+        Hello\\(
+            variable,
+            format: .value
+        )(not-interpolated)
+        \"\"\"
+        """)
+
+        XCTAssertEqual(components, [
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("string"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("\"\"\"", .string),
+            .whitespace("\n"),
+            .token("Hello", .string),
+            .plainText("\\("),
+            .whitespace("\n    "),
+            .plainText("variable,"),
+            .whitespace("\n    "),
+            .plainText("format:"),
+            .whitespace(" "),
+            .plainText("."),
+            .token("value", Splash.TokenType.dotAccess),
+            .whitespace("\n"),
+            .plainText(")"),
+            .token("(not-interpolated)", .string),
+            .whitespace("\n"),
+            .token("\"\"\"", .string)
+        ])
+    }
+    
+    func testMultiLineStringLiteralWithInterpolatedString() {
+        let components = highlighter.highlight("""
+        let string = \"\"\"
+        Hello \\(
+            value ? "Bob"
+        ) Welcome.
+        \"\"\"
+        """)
+
+        XCTAssertEqual(components, [
+            .token("let", .keyword),
+            .whitespace(" "),
+            .plainText("string"),
+            .whitespace(" "),
+            .plainText("="),
+            .whitespace(" "),
+            .token("\"\"\"", .string),
+            .whitespace("\n"),
+            .token("Hello", .string),
+            .whitespace(" "),
+            .plainText("\\("),
+            .whitespace("\n    "),
+            .plainText("value"),
+            .whitespace(" "),
+            .plainText("?"),
+            .whitespace(" "),
+            .token("\"Bob\"", .string),
+            .whitespace("\n"),
+            .plainText(")"),
+            .whitespace(" "),
+            .token("Welcome.", .string),
+            .whitespace("\n"),
+            .token("\"\"\"", .string)
+        ])
+    }
 
     func testSingleLineRawStringLiteral() {
         let components = highlighter.highlight("""

--- a/Tests/SplashTests/Tests/LiteralTests.swift
+++ b/Tests/SplashTests/Tests/LiteralTests.swift
@@ -382,4 +382,27 @@ final class LiteralTests: SyntaxHighlighterTestCase {
             .plainText(")")
         ])
     }
+    
+    /**
+     
+     This test was adding since we ended up having a recursive loop that would crash.
+     
+     Switching to async mode reduces your accessible stack size.
+     */
+    func testNestedMultiline() async {
+        let testString = #"""
+        struct ContentView: View {
+            @State private var text = """
+            ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~
+            """
+            
+            var body: some View {
+                TextEditor(text: $text)
+                    .font(.body)
+                    .frame(width: 300, height: 300)
+            }
+        }
+        """#
+        let _ = highlighter.highlight(testString)
+    }
 }


### PR DESCRIPTION
Currently Splash does not support multi line string interpolation for swift. 

However this is a feature of swift and is very useful to use when blogging as keeping the line length short is important for mobile/iPad viewers. 

Before:
<img width="935" alt="image" src="https://user-images.githubusercontent.com/838127/183227425-66676c09-6076-4cc6-ae87-3de9ee3df39f.png">



After:
<img width="922" alt="image" src="https://user-images.githubusercontent.com/838127/183227413-311405a9-da66-4fba-8133-a8e88200e6b8.png">

This fix now supports multi line text interpolation within multi line strings.


It however does not support dealing with the edge case were there is a string nested within the interpolation that itself includes a closing brace.  I feel that is quite a bit of an edge case and supporting it would add a lot of complexity. 

```swift
let str = """
Hello \(name ?? "closing-branch-within-string-)")
"""
```
