### PR TITLE
Add Swift 5.9 new keywords

### DIFF
--- a/Sources/Splash/Grammar/SwiftGrammar.swift
+++ b/Sources/Splash/Grammar/SwiftGrammar.swift
@@ -82,11 +82,12 @@ private extension SwiftGrammar {
         "continue", "fallthrough", "repeat", "indirect",
         "deinit", "is", "#file", "#line", "#function",
         "dynamic", "some", "#available", "convenience", "unowned",
-        "async", "await", "actor", "any"
+        "async", "await", "actor", "any", "consume", "consuming",
+        "discard", "borrowing", "repeat", "each"
     ] as Set<String>).union(accessControlKeywords)
 
     static let accessControlKeywords: Set<String> = [
-        "public", "internal", "fileprivate", "private"
+        "public", "internal", "fileprivate", "private", "package"
     ]
 
     static let declarationKeywords: Set<String> = [


### PR DESCRIPTION
This PR adds support for new keywords introduced in Swift 5.9:
- `repeat` and `each` for generics
- `consume`, `consuming`, `discard`, `borrowing` for non-copyable structures
- new access control keyword - `package`
