### PR TITLE
Encode newline with break tag

### DIFF
--- a/Sources/Splash/Extensions/Strings/String+HTMLEntities.swift
+++ b/Sources/Splash/Extensions/Strings/String+HTMLEntities.swift
@@ -16,6 +16,8 @@ internal extension StringProtocol {
                 return "&lt;"
             case ">":
                 return "&gt;"
+            case "\n":
+                return "<br>"
             default:
                 return String(character)
             }

--- a/Tests/SplashTests/Tests/HTMLOutputFormatTests.swift
+++ b/Tests/SplashTests/Tests/HTMLOutputFormatTests.swift
@@ -39,4 +39,16 @@ final class HTMLOutputFormatTests: XCTestCase {
         <span class="comment">// Hey I'm a comment!</span>
         """)
     }
+
+    func testEncodingNewlinesWithBreakTag() {
+        let html = highlighter.highlight("""
+        // comment line 1
+        // comment line 2
+        func expressTheCommentAbove()
+        """)
+
+        XCTAssertEqual(html, """
+        <span class=\"comment\">// comment line 1<br>// comment line 2</span>\n<span class=\"keyword\">func</span> expressTheCommentAbove()
+        """)
+    }
 }


### PR DESCRIPTION
Sequential comments are currently output enclosed within a single span tag with newlines between each comment line. This results in a comments like this:

```swift
        // comment line 1
        // comment line 2
        func expressTheCommentAbove()
```

...being displayed in a browser as:

```swift
        // comment line 1 // comment line 2
        func expressTheCommentAbove()
```

This PR adds newlines to the `escapingHTMLEntities()` method so that these newlines are output using the `<br>` tag. Given this change, it may even make sense to rename this method to `encodingHTMLEntities()`.

⚠️ All tests are passing. However, it is important to consider if there are any other cases where this behavior is not what you want. Is there any other case where a single `<span>` covers multiple lines and this new behavior would result in an unexpected output? ⚠️
