### PR TITLE
Fix concurrency issues for Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version: 6.0
 
 /**
  *  Splash

--- a/Sources/Splash/Grammar/Grammar.swift
+++ b/Sources/Splash/Grammar/Grammar.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Protocol used to define the grammar of a language to use for
 /// syntax highlighting. See `SwiftGrammar` for a default implementation
 /// of the Swift language grammar.
-public protocol Grammar {
+public protocol Grammar: Sendable {
     /// The set of characters that make up the delimiters that separates
     /// tokens within the language, such as punctuation characters. You
     /// can control whether delimiters should be merged when forming

--- a/Sources/Splash/Output/AttributedStringOutputFormat.swift
+++ b/Sources/Splash/Output/AttributedStringOutputFormat.swift
@@ -54,7 +54,7 @@ public extension AttributedStringOutputFormat {
 }
 
 private extension NSMutableAttributedString {
-    func append(_ string: String, font: Font.Loaded, color: Color) {
+    func append(_ string: String, font: Font.LoadedFont, color: Color) {
         let attributedString = NSAttributedString(string: string, attributes: [
             .foregroundColor: color,
             .font: font

--- a/Sources/Splash/Output/OutputFormat.swift
+++ b/Sources/Splash/Output/OutputFormat.swift
@@ -11,7 +11,7 @@ import Foundation
 /// NSAttributedString outputs, and custom ones can be defined by
 /// conforming to this protocol and passing the implementation to a
 /// syntax highlighter when it's created.
-public protocol OutputFormat {
+public protocol OutputFormat: Sendable {
     /// The type of builder that this output format uses. The builder's
     /// `Output` type determines the output type of the format.
     associatedtype Builder: OutputBuilder

--- a/Sources/Splash/Syntax/SyntaxHighlighter.swift
+++ b/Sources/Splash/Syntax/SyntaxHighlighter.swift
@@ -12,7 +12,7 @@ import Foundation
 /// To initialize this class, pass the desired output format, such as
 /// `AttributedStringOutputFormat` or `HTMLOutputFormat`, or a custom
 /// implementation. One syntax highlighter may be reused multiple times.
-public struct SyntaxHighlighter<Format: OutputFormat> {
+public struct SyntaxHighlighter<Format: OutputFormat>: Sendable {
     private let format: Format
     private let grammar: Grammar
     private let tokenizer = Tokenizer()

--- a/Sources/Splash/Syntax/SyntaxRule.swift
+++ b/Sources/Splash/Syntax/SyntaxRule.swift
@@ -11,7 +11,7 @@ import Foundation
 /// evaluated, is asked to check whether it matches a given segment
 /// of code. If the rule matches then the rule's token type will be
 /// associated with the given segment's current token.
-public protocol SyntaxRule {
+public protocol SyntaxRule: Sendable {
     /// The token type that this syntax rule represents
     var tokenType: TokenType { get }
 

--- a/Sources/Splash/Theming/Theme.swift
+++ b/Sources/Splash/Theming/Theme.swift
@@ -4,14 +4,17 @@
  *  MIT license - see LICENSE.md
  */
 
-import Foundation
-
 #if !os(Linux)
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import Cocoa
+#endif
 
 /// A theme describes what fonts and colors to use when rendering
 /// certain output formats - such as `NSAttributedString`. Several
 /// default implementations are provided - see Theme+Defaults.swift.
-public struct Theme {
+public struct Theme: Sendable {
     /// What font to use to render the highlighted text
     public var font: Font
     /// What color to use for plain text (no highlighting)

--- a/Sources/Splash/Tokenizing/TokenType.swift
+++ b/Sources/Splash/Tokenizing/TokenType.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Enum defining the possible types of tokens that can be highlighted
-public enum TokenType: Hashable {
+public enum TokenType: Hashable, Sendable {
     /// A keyword, such as `if`, `class`, `let` or attributes such as @available
     case keyword
     /// A token that is part of a string literal


### PR DESCRIPTION
This includes a breaking change related to the `preloaded` case of the `Resource` enum in `Font.swift`, which is necessary in order to make `Resource` sendable.